### PR TITLE
Make combiner truly optional

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/util/MongoTool.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoTool.java
@@ -62,7 +62,10 @@ public class MongoTool extends Configured implements Tool {
 
         log.info( "Mapper Class: " + mapper );
         job.setMapperClass( mapper );
-        job.setCombinerClass( MongoConfigUtil.getCombiner( conf ) );
+        Class<? extends Reducer> combiner = MongoConfigUtil.getCombiner(conf);
+        if (combiner != null) {
+            job.setCombinerClass( combiner );
+        }
         job.setReducerClass( MongoConfigUtil.getReducer( conf ) );
 
         job.setOutputFormatClass( MongoConfigUtil.getOutputFormat( conf ) );


### PR DESCRIPTION
While the combiner is marked as optional, if one is not specified, Hadoop throws a NullPointerException (stack trace below).

```
Exception in thread "main" java.lang.NullPointerException
    at java.lang.Class.isAssignableFrom(Native Method)
    at org.apache.hadoop.conf.Configuration.setClass(Configuration.java:1069)
    at org.apache.hadoop.mapreduce.Job.setCombinerClass(Job.java:152)
    at com.mongodb.hadoop.util.MongoTool.run(MongoTool.java:65)
    at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:65)
    at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:79)
    at com.somecompany.mongohadoop.MyDriver.main(MyDriver.java:29)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.apache.hadoop.util.RunJar.main(RunJar.java:197)
```
