### PR TITLE
Feature/multiple inputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,4 +3,4 @@ name := "mongo-hadoop"
 
 organization := "org.mongodb"
 
-hadoopRelease in ThisBuild := "0.22"
+hadoopRelease in ThisBuild := "0.23"

--- a/core/src/main/java/com/mongodb/hadoop/MongoConfig.java
+++ b/core/src/main/java/com/mongodb/hadoop/MongoConfig.java
@@ -157,16 +157,8 @@ public class MongoConfig {
         MongoConfigUtil.setInputFormat( _conf, val );
     }
 
-    public MongoURI getMongoURI( String key ){
-        return MongoConfigUtil.getMongoURI( _conf, key );
-    }
-
     public MongoURI[] getMongoURIs( String key ){
         return MongoConfigUtil.getMongoURIs( _conf, key );
-    }
-
-    public MongoURI getInputURI(){
-        return MongoConfigUtil.getInputURI( _conf );
     }
 
     public MongoURI[] getInputURIs(){
@@ -177,36 +169,16 @@ public class MongoConfig {
         return MongoConfigUtil.getOutputCollection( _conf );
     }
 
-    public DBCollection getInputCollection(){
-        return MongoConfigUtil.getInputCollection( _conf );
-    }
-
-    public void setMongoURI( String key, MongoURI value ){
-        MongoConfigUtil.setMongoURI( _conf, key, value );
-    }
-
     public void setMongoURIs( String key, MongoURI[] values ){
         MongoConfigUtil.setMongoURIs( _conf, key, values );
-    }
-
-    public void setMongoURIString( String key, String value ){
-        MongoConfigUtil.setMongoURIString( _conf, key, value );
     }
 
     public void setMongoURIsString( String key, String[] values ) {
         MongoConfigUtil.setMongoURIsString( _conf, key, values );
     }
 
-    public void setInputURI( String uri ){
-        MongoConfigUtil.setInputURI( _conf, uri );
-    }
-
     public void setInputURIs( String[] uris ){
         MongoConfigUtil.setInputURIs( _conf, uris );
-    }
-
-    public void setInputURI( MongoURI uri ){
-        MongoConfigUtil.setInputURI( _conf, uri );
     }
 
     public void setInputURIs( MongoURI[] uris ){
@@ -334,7 +306,7 @@ public class MongoConfig {
     public void setReadSplitsFromSecondary( boolean value ) {
         MongoConfigUtil.setReadSplitsFromSecondary( _conf, value );
     }
-    
+
     /**
      * If CREATE_INPUT_SPLITS is true but SPLITS_USE_CHUNKS is false, Mongo-Hadoop will attempt
      * to create custom input splits for you.  By default it will split on {@code _id}, which is a
@@ -380,7 +352,7 @@ public class MongoConfig {
     public void setInputSplitKey( DBObject key ) {
         MongoConfigUtil.setInputSplitKey( _conf, key );
     }
-            
+
     /**
      * If {@code true}, the driver will attempt to split the MongoDB Input data (if reading from Mongo) into
      * multiple InputSplits to allow parallelism/concurrency in processing within Hadoop.  That is to say,
@@ -426,11 +398,11 @@ public class MongoConfig {
     public void setInputKey( String fieldName ) {
         MongoConfigUtil.setInputKey( _conf, fieldName );
     }
-    
+
     public boolean isNoTimeout() {
         return MongoConfigUtil.isNoTimeout( _conf );
     }
-    
+
     public void setNoTimeout( boolean value ) {
         MongoConfigUtil.setNoTimeout( _conf, value );
     }

--- a/core/src/main/java/com/mongodb/hadoop/MongoConfig.java
+++ b/core/src/main/java/com/mongodb/hadoop/MongoConfig.java
@@ -161,8 +161,16 @@ public class MongoConfig {
         return MongoConfigUtil.getMongoURI( _conf, key );
     }
 
+    public MongoURI[] getMongoURIs( String key ){
+        return MongoConfigUtil.getMongoURIs( _conf, key );
+    }
+
     public MongoURI getInputURI(){
         return MongoConfigUtil.getInputURI( _conf );
+    }
+
+    public MongoURI[] getInputURIs(){
+        return MongoConfigUtil.getInputURIs( _conf );
     }
 
     public DBCollection getOutputCollection(){
@@ -177,16 +185,32 @@ public class MongoConfig {
         MongoConfigUtil.setMongoURI( _conf, key, value );
     }
 
+    public void setMongoURIs( String key, MongoURI[] values ){
+        MongoConfigUtil.setMongoURIs( _conf, key, values );
+    }
+
     public void setMongoURIString( String key, String value ){
         MongoConfigUtil.setMongoURIString( _conf, key, value );
+    }
+
+    public void setMongoURIsString( String key, String[] values ) {
+        MongoConfigUtil.setMongoURIsString( _conf, key, values );
     }
 
     public void setInputURI( String uri ){
         MongoConfigUtil.setInputURI( _conf, uri );
     }
 
+    public void setInputURIs( String[] uris ){
+        MongoConfigUtil.setInputURIs( _conf, uris );
+    }
+
     public void setInputURI( MongoURI uri ){
         MongoConfigUtil.setInputURI( _conf, uri );
+    }
+
+    public void setInputURIs( MongoURI[] uris ){
+        MongoConfigUtil.setInputURIs( _conf, uris );
     }
 
     public MongoURI getOutputURI(){

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
@@ -57,7 +57,6 @@ public class MongoConfigUtil {
     public static final String JOB_OUTPUT_KEY = "mongo.job.output.key";
     public static final String JOB_OUTPUT_VALUE = "mongo.job.output.value";
 
-    public static final String INPUT_URI = "mongo.input.uri";
     public static final String INPUT_URIS = "mongo.input.uris";
     public static final String OUTPUT_URI = "mongo.output.uri";
 
@@ -259,7 +258,6 @@ public class MongoConfigUtil {
 
         for( int i = 0; i < raw_uris.length; i++ ) {
             if ( raw_uris[i] != null && !raw_uris[i].trim().isEmpty() ) {
-                log.info("getMongoURIs(): raw_uris[" + i + "]=" + raw_uris[i]);
                 uris[i] = new MongoURI(raw_uris[i]);
             }
             else {
@@ -268,10 +266,6 @@ public class MongoConfigUtil {
         }
 
         return uris;
-    }
-
-    public static MongoURI getInputURI( Configuration conf ){
-        return getMongoURI( conf, INPUT_URI );
     }
 
     public static MongoURI[] getInputURIs( Configuration conf ){
@@ -310,17 +304,6 @@ public class MongoConfigUtil {
         }
     }
 
-    public static DBCollection getInputCollection( Configuration conf ){
-        try {
-            final MongoURI _uri = getInputURI( conf );
-            return getCollection( _uri );
-        }
-        catch ( final Exception e ) {
-            throw new IllegalArgumentException(
-                    "Unable to connect to MongoDB Input Collection at '" + getInputURI( conf ) + "'", e );
-        }
-    }
-
     public static void setMongoURI( Configuration conf, String key, MongoURI value ){
         conf.set( key, value.toString() ); // todo - verify you can toString a
         // URI object
@@ -337,12 +320,8 @@ public class MongoConfigUtil {
         }
     }
 
-    public static void setInputURI( Configuration conf, String uri ){
-        setMongoURIString( conf, INPUT_URI, uri );
-    }
-
-    public static void setInputURI( Configuration conf, MongoURI uri ){
-        setMongoURI( conf, INPUT_URI, uri );
+    public static void setMongoURIs( Configuration conf, String key, MongoURI[] values ) {
+        conf.set( key, Arrays.toString(values) );
     }
 
     public static void setMongoURIsString( Configuration conf, String key, String[] values ){
@@ -357,10 +336,6 @@ public class MongoConfigUtil {
         }
 
         setMongoURIs( conf, key, uris );
-    }
-
-    public static void setMongoURIs( Configuration conf, String key, MongoURI[] values ) {
-        conf.set( key, Arrays.toString(values) );
     }
 
     public static void setInputURIs( Configuration conf, String[] uris ){
@@ -539,11 +514,11 @@ public class MongoConfigUtil {
     public static void setInputSplitKey( Configuration conf, DBObject key ) {
         setDBObject( conf, INPUT_SPLIT_KEY_PATTERN, key );
     }
-    
+
     public static String getInputSplitKeyPattern( Configuration conf ) {
         return conf.get( INPUT_SPLIT_KEY_PATTERN, "{ \"_id\": 1 }" );
     }
-    
+
     public static DBObject getInputSplitKey( Configuration conf ) {
         try {
             final String json = getInputSplitKeyPattern( conf );
@@ -563,15 +538,15 @@ public class MongoConfigUtil {
         // TODO (bwm) - validate key rules?
         conf.set( INPUT_KEY, fieldName );
     }
-    
+
     public static String getInputKey( Configuration conf ) {
         return conf.get( INPUT_KEY, "_id" );
     }
-   
+
     public static void setNoTimeout( Configuration conf, boolean value ) {
         conf.setBoolean( INPUT_NOTIMEOUT, value );
     }
-    
+
     public static boolean isNoTimeout( Configuration conf ) {
         return conf.getBoolean( INPUT_NOTIMEOUT, false );
     }

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
@@ -17,6 +17,8 @@
 
 package com.mongodb.hadoop.util;
 
+import java.util.*;
+
 import com.mongodb.*;
 import com.mongodb.util.*;
 import org.apache.commons.logging.*;
@@ -56,6 +58,7 @@ public class MongoConfigUtil {
     public static final String JOB_OUTPUT_VALUE = "mongo.job.output.value";
 
     public static final String INPUT_URI = "mongo.input.uri";
+    public static final String INPUT_URIS = "mongo.input.uris";
     public static final String OUTPUT_URI = "mongo.output.uri";
 
     /**
@@ -250,8 +253,29 @@ public class MongoConfigUtil {
             return null;
     }
 
+    public static MongoURI[] getMongoURIs( Configuration conf, String key ){
+        final String[] raw_uris = conf.get( key ).replace("[", "").replace("]", "").split(", ");
+        MongoURI[] uris = new MongoURI[raw_uris.length];
+
+        for( int i = 0; i < raw_uris.length; i++ ) {
+            if ( raw_uris[i] != null && !raw_uris[i].trim().isEmpty() ) {
+                log.info("getMongoURIs(): raw_uris[" + i + "]=" + raw_uris[i]);
+                uris[i] = new MongoURI(raw_uris[i]);
+            }
+            else {
+                uris[i] = null;
+            }
+        }
+
+        return uris;
+    }
+
     public static MongoURI getInputURI( Configuration conf ){
         return getMongoURI( conf, INPUT_URI );
+    }
+
+    public static MongoURI[] getInputURIs( Configuration conf ){
+        return getMongoURIs( conf, INPUT_URIS );
     }
 
     public static DBCollection getCollection( MongoURI uri ){
@@ -319,6 +343,32 @@ public class MongoConfigUtil {
 
     public static void setInputURI( Configuration conf, MongoURI uri ){
         setMongoURI( conf, INPUT_URI, uri );
+    }
+
+    public static void setMongoURIsString( Configuration conf, String key, String[] values ){
+        MongoURI[] uris = new MongoURI[values.length];
+        for(int i = 0; i < values.length; i++) {
+            try {
+                uris[i] = new MongoURI( values[i] );
+            }
+            catch ( final Exception e ) {
+                throw new IllegalArgumentException( "Invalid Mongo URI '" + values[i] + "' for Input URI", e);
+            }
+        }
+
+        setMongoURIs( conf, key, uris );
+    }
+
+    public static void setMongoURIs( Configuration conf, String key, MongoURI[] values ) {
+        conf.set( key, Arrays.toString(values) );
+    }
+
+    public static void setInputURIs( Configuration conf, String[] uris ){
+        setMongoURIsString( conf, INPUT_URIS, uris );
+    }
+
+    public static void setInputURIs( Configuration conf, MongoURI[] uris ){
+        setMongoURIs( conf, INPUT_URIS, uris );
     }
 
     public static MongoURI getOutputURI( Configuration conf ){

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
@@ -40,7 +40,6 @@ public class MongoSplitter {
          * split; Actual querying will be done on the individual mappers.
          */
         MongoURI[] uris = conf.getInputURIs();
-        log.info("MongoSplitter::calculateSplits(): uris=" + Arrays.toString(uris));
 
         //connecting to the individual backend mongods is not safe, do not do so by default
         final boolean useShards = conf.canReadSplitsFromShards();
@@ -82,7 +81,7 @@ public class MongoSplitter {
             }
             else {
                 log.info( "Creation of Input Splits is disabled; Non-Split mode calculation entering." );
-                splits.addAll(calculateSingleSplit( conf ));
+                splits.addAll(calculateSingleSplit( conf, uri ));
             }
         }
 
@@ -157,10 +156,10 @@ public class MongoSplitter {
                                     conf.getSort(), conf.getLimit(), conf.getSkip(), conf.isNoTimeout() );
     }
     
-    private static List<InputSplit> calculateSingleSplit( MongoConfig conf ){
+    private static List<InputSplit> calculateSingleSplit( MongoConfig conf, MongoURI uri ){
         final List<InputSplit> splits = new ArrayList<InputSplit>( 1 );
         // no splits, no sharding
-        splits.add( new MongoInputSplit( conf.getInputURI(), conf.getInputKey(), conf.getQuery(), 
+        splits.add( new MongoInputSplit( uri, conf.getInputKey(), conf.getQuery(), 
                                          conf.getFields(), conf.getSort(), conf.getLimit(), conf.getSkip(),
                                          conf.isNoTimeout() ) );
 
@@ -342,7 +341,6 @@ public class MongoSplitter {
                     log.debug( "[" + numChunks + "/" + numExpectedChunks + "] new query is: " + shardKeyQuery );
                 }
 
-                //MongoURI inputURI = conf.getInputURI();
                 MongoURI inputURI = uri;
 
                 if ( useShards ){

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
@@ -39,50 +39,54 @@ public class MongoSplitter {
          * On the jobclient side we want *ONLY* the min and max ids for each
          * split; Actual querying will be done on the individual mappers.
          */
-        MongoURI uri = conf.getInputURI();
         MongoURI[] uris = conf.getInputURIs();
         log.info("MongoSplitter::calculateSplits(): uris=" + Arrays.toString(uris));
 
-        Mongo mongo;
-        try {
-            mongo = uri.connect();
-        } catch (UnknownHostException e) {
-            throw new IllegalStateException( " Unable to connect to MongoDB at '" + uri + "'", e);
-        }
-
-        DB db = mongo.getDB( uri.getDatabase() );
-        DBCollection coll = db.getCollection( uri.getCollection() );
-        final CommandResult stats = coll.getStats();
-
-        final boolean isSharded = stats.getBoolean( "sharded", false );
-
         //connecting to the individual backend mongods is not safe, do not do so by default
         final boolean useShards = conf.canReadSplitsFromShards();
-
         final boolean useChunks = conf.isShardChunkedSplittingEnabled();
-
         final boolean slaveOk = conf.canReadSplitsFromSecondary();
 
-        log.info(" Calculate Splits Code ... Use Shards? " + useShards + ", Use Chunks? " + useChunks + "; Collection Sharded? " + isSharded);
-        if (conf.createInputSplits()) {
-            log.info( "Creation of Input Splits is enabled." );
-            if (isSharded && (useShards || useChunks)){  // todo I don't think these settings can be run together
-                if (useShards && useChunks)
-                    log.warn( "Combining 'use chunks' and 'read from shards directly' can have unexpected & erratic behavior in a live system due to chunk migrations. " );
+        List<InputSplit> splits = new ArrayList<InputSplit>();
 
-                log.info( "Sharding mode calculation entering." );
-                return calculateShardedSplits( conf, useShards, useChunks, slaveOk, uri, mongo );
-            }
-            else { // perfectly ok for sharded setups to run with a normally calculated split. May even be more efficient for some cases
-                log.info( "Using Unsharded Split mode (Calculating multiple splits though)" );
-                return calculateUnshardedSplits( conf, slaveOk, uri, coll );
+        for (MongoURI uri: uris) {
+
+            Mongo mongo;
+            try {
+                mongo = uri.connect();
+            } catch (UnknownHostException e) {
+                throw new IllegalStateException( " Unable to connect to MongoDB at '" + uri + "'", e);
             }
 
+            DB db = mongo.getDB( uri.getDatabase() );
+            DBCollection coll = db.getCollection( uri.getCollection() );
+            final CommandResult stats = coll.getStats();
+
+            final boolean isSharded = stats.getBoolean( "sharded", false );
+
+            log.info(" Calculate Splits Code ... Use Shards? " + useShards + ", Use Chunks? " + useChunks + "; Collection Sharded? " + isSharded);
+            if (conf.createInputSplits()) {
+                log.info( "Creation of Input Splits is enabled." );
+                if (isSharded && (useShards || useChunks)){  // todo I don't think these settings can be run together
+                    if (useShards && useChunks)
+                        log.warn( "Combining 'use chunks' and 'read from shards directly' can have unexpected & erratic behavior in a live system due to chunk migrations. " );
+
+                    log.info( "Sharding mode calculation entering." );
+                    splits.addAll(calculateShardedSplits( conf, useShards, useChunks, slaveOk, uri, mongo ));
+                }
+                else { // perfectly ok for sharded setups to run with a normally calculated split. May even be more efficient for some cases
+                    log.info( "Using Unsharded Split mode (Calculating multiple splits though)" );
+                    splits.addAll(calculateUnshardedSplits( conf, slaveOk, uri, coll ));
+                }
+
+            }
+            else {
+                log.info( "Creation of Input Splits is disabled; Non-Split mode calculation entering." );
+                splits.addAll(calculateSingleSplit( conf ));
+            }
         }
-        else {
-            log.info( "Creation of Input Splits is disabled; Non-Split mode calculation entering." );
-            return calculateSingleSplit( conf );
-        }
+
+        return splits;
     }
 
     private static List<InputSplit> calculateUnshardedSplits( MongoConfig conf, boolean slaveOk, 
@@ -116,29 +120,29 @@ public class MongoSplitter {
                 log.warn( "WARNING: No Input Splits were calculated by the split code. "
                           + "Proceeding with a *single* split. Data may be too small, try lowering 'mongo.input.split_size' "
                           + "if this is undesirable." );
-            splits.add( _split( conf, q, null, null ) ); // no splits really. Just do the whole thing data is likely small
+            splits.add( _split( uri, conf, q, null, null ) ); // no splits really. Just do the whole thing data is likely small
         }
         else {
             log.info( "Calculated " + splitData.size() + " splits." );
 
             DBObject lastKey = (DBObject) splitData.get( 0 );
 
-            splits.add( _split( conf, q, null, lastKey ) ); // first "min" split
+            splits.add( _split( uri, conf, q, null, lastKey ) ); // first "min" split
 
             for (int i = 1; i < splitData.size(); i++ ) {
                 final DBObject _tKey = (DBObject) splitData.get( i );
-                splits.add( _split( conf, q, lastKey, _tKey) );
+                splits.add( _split( uri, conf, q, lastKey, _tKey) );
                 lastKey = _tKey;
             }
 
-            splits.add( _split( conf, q, lastKey, null ) ); // last "max" split
+            splits.add( _split( uri, conf, q, lastKey, null ) ); // last "max" split
         }
 
         return splits;
 
     }
 
-    private static MongoInputSplit _split( MongoConfig conf, DBObject q, DBObject min, DBObject max ) {
+    private static MongoInputSplit _split( MongoURI uri, MongoConfig conf, DBObject q, DBObject min, DBObject max ) {
         BasicDBObjectBuilder b = BasicDBObjectBuilder.start( "$query", q );
         if (min != null) // min ceiling
            b.add( "$min", min );
@@ -149,7 +153,7 @@ public class MongoSplitter {
         final DBObject query = b.get();
         log.trace( "Assembled Query: " + query );
 
-        return new MongoInputSplit( conf.getInputURI(), conf.getInputKey(), query, conf.getFields(), 
+        return new MongoInputSplit( uri, conf.getInputKey(), query, conf.getFields(), 
                                     conf.getSort(), conf.getLimit(), conf.getSkip(), conf.isNoTimeout() );
     }
     
@@ -338,7 +342,8 @@ public class MongoSplitter {
                     log.debug( "[" + numChunks + "/" + numExpectedChunks + "] new query is: " + shardKeyQuery );
                 }
 
-                MongoURI inputURI = conf.getInputURI();
+                //MongoURI inputURI = conf.getInputURI();
+                MongoURI inputURI = uri;
 
                 if ( useShards ){
                     final String shardname = row.getString( "shard" );

--- a/examples/wordcount/src/main/java/com/mongodb/hadoop/examples/wordcount/WordCount.java
+++ b/examples/wordcount/src/main/java/com/mongodb/hadoop/examples/wordcount/WordCount.java
@@ -74,7 +74,8 @@ public class WordCount {
     public static void main( String[] args ) throws Exception{
 
         final Configuration conf = new Configuration();
-        MongoConfigUtil.setInputURI( conf, "mongodb://localhost/test.in" );
+        String[] inputURIs = {"mongodb://localhost/test.in"};
+        MongoConfigUtil.setInputURIs( conf, inputURIs );
         MongoConfigUtil.setOutputURI( conf, "mongodb://localhost/test.out" );
         System.out.println( "Conf: " + conf );
 

--- a/examples/wordcount_split_test/src/main/java/com/mongodb/hadoop/examples/wordcount/split/WordCountSplitTest.java
+++ b/examples/wordcount_split_test/src/main/java/com/mongodb/hadoop/examples/wordcount/split/WordCountSplitTest.java
@@ -106,7 +106,7 @@ public class WordCountSplitTest extends MongoTool {
         final com.mongodb.MongoURI outputUri = MongoConfigUtil.getOutputURI( conf );
         if ( outputUri == null )
             throw new IllegalStateException( "output uri is not set" );
-        if ( MongoConfigUtil.getInputURI( conf ) == null )
+        if ( MongoConfigUtil.getInputURIs( conf ) == null )
             throw new IllegalStateException( "input uri is not set" );
         final String outputCollectionName = outputUri.getCollection();
 
@@ -162,7 +162,8 @@ public class WordCountSplitTest extends MongoTool {
     private final static void test( boolean useShards, boolean useChunks, Boolean slaveok, boolean useQuery )
             throws Exception{
         final Configuration conf = new Configuration();
-        MongoConfigUtil.setInputURI( conf, "mongodb://localhost:30000/test.lines" );
+        String[] inputURIs = {"mongodb://localhost:30000/test.lines"};
+        MongoConfigUtil.setInputURI( conf, inputURIs );
         conf.setBoolean( MongoConfigUtil.SPLITS_USE_SHARDS, useShards );
         conf.setBoolean( MongoConfigUtil.SPLITS_USE_CHUNKS, useChunks );
 

--- a/streaming/src/main/java/com/mongodb/hadoop/streaming/MongoStreamJob.java
+++ b/streaming/src/main/java/com/mongodb/hadoop/streaming/MongoStreamJob.java
@@ -31,7 +31,6 @@ public class MongoStreamJob extends StreamJobPatch {
             log.info( "Process Args" );
             processArguments();
             log.info( "Args processed." );
-            MongoConfigUtil.setInputURI( conf, _inputURI );
             MongoConfigUtil.setInputURIs( conf, _inputURIs );
             MongoConfigUtil.setOutputURI( conf, _outputURI );
             setJobConf();

--- a/streaming/src/main/java/com/mongodb/hadoop/streaming/MongoStreamJob.java
+++ b/streaming/src/main/java/com/mongodb/hadoop/streaming/MongoStreamJob.java
@@ -32,6 +32,7 @@ public class MongoStreamJob extends StreamJobPatch {
             processArguments();
             log.info( "Args processed." );
             MongoConfigUtil.setInputURI( conf, _inputURI );
+            MongoConfigUtil.setInputURIs( conf, _inputURIs );
             MongoConfigUtil.setOutputURI( conf, _outputURI );
             setJobConf();
             jobConf_.setOutputKeyClass( BSONWritable.class );

--- a/streaming/src/main/java/org/apache/hadoop/streaming/StreamJobPatch.java
+++ b/streaming/src/main/java/org/apache/hadoop/streaming/StreamJobPatch.java
@@ -52,7 +52,9 @@ public class StreamJobPatch extends StreamJob {
           exitUsage(argv_.length > 0 && "-info".equals(argv_[0]));
         }
         if (cmdLine != null){
-            _inputURI =  cmdLine.getOptionValue("inputURI"); 
+            _inputURI =  cmdLine.getOptionValue("inputURI");
+            _inputURIs = cmdLine.getOptionValues("inputURI");
+
             _outputURI =  cmdLine.getOptionValue("outputURI"); 
             verbose_ =  cmdLine.hasOption("verbose");
             detailedUsage_ = cmdLine.hasOption("info");
@@ -149,6 +151,7 @@ public class StreamJobPatch extends StreamJob {
     }
 
     protected String _inputURI;
+    protected String[] _inputURIs;
     protected String _outputURI;
     protected CommandLineParser _parser = new BasicParser(); 
     protected Options _options = new Options();

--- a/streaming/src/main/java/org/apache/hadoop/streaming/StreamJobPatch.java
+++ b/streaming/src/main/java/org/apache/hadoop/streaming/StreamJobPatch.java
@@ -10,7 +10,7 @@ import java.util.*;
 import java.util.regex.*;
 
 public class StreamJobPatch extends StreamJob {
-    
+
     protected void processArguments() throws Exception {
         log.info("Setup Options'");
         setupOptions();
@@ -52,7 +52,6 @@ public class StreamJobPatch extends StreamJob {
           exitUsage(argv_.length > 0 && "-info".equals(argv_[0]));
         }
         if (cmdLine != null){
-            _inputURI =  cmdLine.getOptionValue("inputURI");
             _inputURIs = cmdLine.getOptionValues("inputURI");
 
             _outputURI =  cmdLine.getOptionValue("outputURI"); 
@@ -62,14 +61,14 @@ public class StreamJobPatch extends StreamJob {
             mapCmd_ = cmdLine.getOptionValue("mapper"); 
             comCmd_ = cmdLine.getOptionValue("combiner"); 
             redCmd_ = cmdLine.getOptionValue("reducer"); 
-      
-                     
+
+
             String fsName = cmdLine.getOptionValue("dfs");
             if (null != fsName){
                 LOG.warn("-dfs option is deprecated, please use -fs instead.");
                 config_.set("fs.default.name", fsName);
             }
-      
+
             inputFormatSpec_ = "com.mongodb.hadoop.mapred.MongoInputFormat";
             outputFormatSpec_ = "com.mongodb.hadoop.mapred.MongoOutputFormat";
             additionalConfSpec_ = cmdLine.getOptionValue("additionalconfspec"); 
@@ -78,7 +77,7 @@ public class StreamJobPatch extends StreamJob {
             mapDebugSpec_ = cmdLine.getOptionValue("mapdebug");    
             reduceDebugSpec_ = cmdLine.getOptionValue("reducedebug");
             ioSpec_ = "bson";
-      
+
             String[] car = cmdLine.getOptionValues("cacheArchive"); 
             if (null != car && car.length > 0){
                 LOG.warn("-cacheArchive option is deprecated, please use -archives instead.");
@@ -94,7 +93,7 @@ public class StreamJobPatch extends StreamJob {
                     cacheFiles = (cacheFiles == null)?s :cacheFiles + "," + s;  
                 }
             }
-      
+
             String[] jobconf = cmdLine.getOptionValues("jobconf"); 
             if (null != jobconf && jobconf.length > 0){
                 LOG.warn("-jobconf option is deprecated, please use -D instead.");
@@ -103,7 +102,7 @@ public class StreamJobPatch extends StreamJob {
                     config_.set(parts[0], parts[1]);
                 }
             }
-      
+
             String[] cmd = cmdLine.getOptionValues("cmdenv"); 
             if (null != cmd && cmd.length > 0){
                 for(String s : cmd) {
@@ -119,15 +118,15 @@ public class StreamJobPatch extends StreamJob {
 
     }
     private void setupOptions(){
-    
-        addOption("inputURI", "MongoDB URI for where to read input data from", 
+
+        addOption("inputURI", "MongoDB URI for where to read input data from",
                               "inputURI", 1, true);
-        addOption("outputURI", "MongoDB URI for where to write output data to", 
+        addOption("outputURI", "MongoDB URI for where to write output data to",
                                "outputURI", 1, true);
         addOption("mapper", "The streaming command to run", "cmd", 1, false);
         addOption("combiner", "The streaming command to run", "cmd", 1, false);
-        // reducer could be NONE 
-        addOption("reducer", "The streaming command to run", "cmd", 1, false); 
+        // reducer could be NONE
+        addOption("reducer", "The streaming command to run", "cmd", 1, false);
         addOption("jt", "Optional. Override JobTracker configuration", "<h:p>|local", 1, false);
         addOption("additionalconfspec", "Optional.", "spec", 1, false);
         addOption("inputformat", "Optional.", "spec", 1, false);
@@ -141,19 +140,18 @@ public class StreamJobPatch extends StreamJob {
         addOption("cacheFile", "File name URI", "fileNameURI", Integer.MAX_VALUE, false);
         addOption("cacheArchive", "File name URI", "fileNameURI", Integer.MAX_VALUE, false);
         addOption("io", "Optional.", "spec", 1, false);
-        addOption("file", "File to be shipped in the Job jar file", "file", Integer.MAX_VALUE, false); 
-        
+        addOption("file", "File to be shipped in the Job jar file", "file", Integer.MAX_VALUE, false);
+
         // boolean properties
-        addBoolOption("verbose", "print verbose output"); 
-        addBoolOption("info", "print verbose output"); 
-        addBoolOption("help", "print this help message"); 
-        addBoolOption("debug", "print debug output"); 
+        addBoolOption("verbose", "print verbose output");
+        addBoolOption("info", "print verbose output");
+        addBoolOption("help", "print this help message");
+        addBoolOption("debug", "print debug output");
     }
 
-    protected String _inputURI;
     protected String[] _inputURIs;
     protected String _outputURI;
-    protected CommandLineParser _parser = new BasicParser(); 
+    protected CommandLineParser _parser = new BasicParser();
     protected Options _options = new Options();
     private static final Log log = LogFactory.getLog(StreamJobPatch.class);
 }


### PR DESCRIPTION
Up to date code to allow you to run a hadoop job against multiple collections.  Running a job requires that you provide multiple inputURIs.

For example, if you want to run a streaming job, you can invoke hadoop like:

$HADOOP_COMMON_HOME/bin/hadoop jar target/mongo-hadoop-streaming-assembly-1.0.0-rc1-SNAPSHOT.jar -mapper pymapper.py -reducer pyreducer.py -inputURI mongodb://127.0.0.1/test.users -inputURI mongodb://127.0.0.1/test.documents -outputURI mongodb://127.0.0.1/test.mr_user_document_join -file pymapper.py -file pyreducer.py