### PR TITLE
Develop/multipleinputs

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/MongoConfig.java
+++ b/core/src/main/java/com/mongodb/hadoop/MongoConfig.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.io.*;
 import org.apache.hadoop.mapreduce.*;
 
 import java.io.*;
+import java.util.List;
 
 // Hadoop
 // Commons
@@ -157,12 +158,24 @@ public class MongoConfig {
         MongoConfigUtil.setInputFormat( _conf, val );
     }
 
+    public MongoRequest getMongoRequest (String uri) {
+    	return MongoConfigUtil.getMongoRequest( _conf, uri );
+    }
+
+    public List<MongoRequest> getMongoRequests () {
+    	return MongoConfigUtil.getMongoRequests( _conf );
+    }
+
     public MongoURI getMongoURI( String key ){
         return MongoConfigUtil.getMongoURI( _conf, key );
     }
 
     public MongoURI getInputURI(){
         return MongoConfigUtil.getInputURI( _conf );
+    }
+
+    public MongoURI getInputURI(Class<? extends Mapper> mapper){
+        return MongoConfigUtil.getInputURI( _conf , mapper );
     }
 
     public DBCollection getOutputCollection(){
@@ -356,7 +369,7 @@ public class MongoConfig {
     public void setInputSplitKey( DBObject key ) {
         MongoConfigUtil.setInputSplitKey( _conf, key );
     }
-            
+
     /**
      * If {@code true}, the driver will attempt to split the MongoDB Input data (if reading from Mongo) into
      * multiple InputSplits to allow parallelism/concurrency in processing within Hadoop.  That is to say,

--- a/core/src/main/java/com/mongodb/hadoop/input/DelegatingInputFormat.java
+++ b/core/src/main/java/com/mongodb/hadoop/input/DelegatingInputFormat.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hadoop.input;
+
+import com.mongodb.hadoop.MongoInputFormat;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.*;
+import org.apache.hadoop.mapreduce.lib.input.DelegatingRecordReader;
+import org.apache.hadoop.mapreduce.lib.input.TaggedInputSplitGenerator;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * An {@link InputFormat} that delegates behavior of paths to multiple other
+ * InputFormats.
+ * 
+ * @see org.apache.hadoop.mapreduce.lib.input.MultipleInputs#addInputPath(Job, Path, Class, Class)
+ */
+public class DelegatingInputFormat<K, V> extends InputFormat<K, V> {
+
+  @SuppressWarnings("unchecked")
+	public List<InputSplit> getSplits(JobContext job) throws IOException, InterruptedException {
+	  Configuration conf = job.getConfiguration();
+	  Job jobCopy =new Job(conf);
+	  List<InputSplit> splits = new ArrayList<InputSplit>();
+	  Map<Path, InputFormat> formatMap = MongoMultipleInputs.getInputFormatMap(job);
+	  Map<Path, Class<? extends Mapper>> mapperMap = MongoMultipleInputs.getMapperTypeMap(job);
+//     Map<Class<? extends InputFormat>, List<Path>> formatPaths	= new HashMap<Class<? extends InputFormat>, List<Path>>();
+
+	  for (Entry<Path, InputFormat> entry : formatMap.entrySet()) {
+		  InputFormat formatClass = (InputFormat) ReflectionUtils.newInstance(entry.getValue().getClass(), conf);
+		  Class<? extends Mapper> mapperClass;
+		  mapperClass = mapperMap.get(entry.getKey());
+		  try{
+			  List<InputSplit> pathSplits = ((MongoInputFormat) formatClass).getSplits(jobCopy, entry.getKey());
+			  for (InputSplit pathSplit : pathSplits) {
+				  splits.add(TaggedInputSplitGenerator.getTaggedInputSplit(pathSplit, conf, formatClass.getClass(), mapperClass));
+			  }
+		  }catch(ClassCastException e){
+			  List<InputSplit> pathSplits = formatClass.getSplits(jobCopy);
+			  for (InputSplit pathSplit : pathSplits) {
+				  splits.add(TaggedInputSplitGenerator.getTaggedInputSplit(pathSplit, conf, formatClass.getClass(), mapperClass));
+			  }
+		  }
+	  }
+	  return splits;
+  }
+			
+	@Override
+	public RecordReader<K, V> createRecordReader(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+		return new DelegatingRecordReader<K, V>(split, context);
+	}
+	private static final Log log = LogFactory.getLog( DelegatingInputFormat.class );
+}

--- a/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
+++ b/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
@@ -82,7 +82,7 @@ public class MongoInputSplit extends InputSplit implements Writable {
                                                add( "uri", _mongoURI.toString() ).
                                                add( "key", _keyField ).
                                                add( "query", _querySpec ).
-                                               add( "field", _fieldSpec ).                                              
+                                               add( "field", _fieldSpec ).
                                                add( "sort", _sortSpec ).
                                                add( "limit", _limit ).
                                                add( "skip", _skip ).
@@ -115,13 +115,13 @@ public class MongoInputSplit extends InputSplit implements Writable {
             // TODO - Figure out how to gracefully mark this as an empty
             log.info( "No Length Header available." + e );
             spec = new BasicDBObject();
-        }         
-        
+        }
+
         _mongoURI = new MongoURI((String) spec.get( "uri" ));
-        _keyField = (String) spec.get( "key" );
-        _querySpec = new BasicDBObject( ((BSONObject) spec.get( "query" )).toMap() );
-        _fieldSpec = new BasicDBObject( ((BSONObject) spec.get( "field" )).toMap() ) ;
-        _sortSpec = new BasicDBObject( ((BSONObject) spec.get( "sort" )).toMap() );
+        _keyField = spec.containsField("key") ? (String) spec.get( "key" ) : "";
+        _querySpec = spec.containsField("query") && spec.get("query") != null ? new BasicDBObject( ((BSONObject) spec.get( "query" )).toMap() ) : new BasicDBObject();
+        _fieldSpec = spec.containsField("field") && spec.get("field") != null ?new BasicDBObject( ((BSONObject) spec.get( "field" )).toMap() ) : new BasicDBObject() ;
+        _sortSpec = spec.containsField("sort") && spec.get("sort") != null ?new BasicDBObject( ((BSONObject) spec.get( "sort" )).toMap() ) : new BasicDBObject();
         _limit = (Integer) spec.get( "limit" );
         _skip = (Integer) spec.get( "skip" );
         _notimeout = (Boolean) spec.get( "notimeout" );
@@ -147,7 +147,7 @@ public class MongoInputSplit extends InputSplit implements Writable {
     }
 
     BSONEncoder getBSONEncoder(){
-        if (_bsonEncoder == null) 
+        if (_bsonEncoder == null)
             _bsonEncoder = new BasicBSONEncoder();
         return _bsonEncoder;
     }

--- a/core/src/main/java/com/mongodb/hadoop/input/MongoMultipleInputs.java
+++ b/core/src/main/java/com/mongodb/hadoop/input/MongoMultipleInputs.java
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.hadoop.input;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.input.DelegatingMapper;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.MongoURI;
+import com.mongodb.hadoop.util.MongoConfigUtil;
+import com.mongodb.hadoop.util.MongoRequest;
+
+/**
+ * This class supports MapReduce jobs that have multiple input paths with
+ * a different {@link InputFormat} and {@link Mapper} for each path 
+ */
+public class MongoMultipleInputs {
+	
+  /**
+   * Add a {@link Path} with a custom {@link InputFormat} and
+   * {@link Mapper} to the list of inputs for the map-reduce job.
+   * 
+   * @param job The {@link Job}
+   * @param path {@link Path} to be added to the list of inputs for the job
+   * @param inputFormatClass {@link InputFormat} class to use for this path
+   * @param mapperClass {@link Mapper} class to use for this path
+   * @param query {@link DBObject} query for path and mapper
+   * @param fields {@link DBObject} fields for path and mapper
+   * @param sort {@link DBObject} sort for path and mapper
+   * @param limit {@link int} limit for path and mapper
+   * @param skip {@link int} skip for path and mapper
+   */
+  @SuppressWarnings("unchecked")
+  public static void addInputPath(Job job, String uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  String query, String fields, String sort, int limit, int skip) {
+	  Configuration conf = job.getConfiguration();
+	  MongoConfigUtil.addMongoRequest(conf, uri, inputFormatClass, mapperClass, query, fields, sort, limit, skip);
+	  
+	  job.setMapperClass(DelegatingMapper.class);
+	  job.setInputFormatClass(DelegatingInputFormat.class);
+  }
+  
+  public static void addInputPath(Job job, String uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  DBObject query, DBObject fields, DBObject sort, int limit, int skip) {
+	  addInputPath(job, uri, inputFormatClass, mapperClass, query != null ? query.toString() : "", fields != null ? fields.toString() : "", sort != null ? sort.toString() : "", limit, skip);
+  }
+  public static void addInputPath(Job job, MongoURI uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  DBObject query, DBObject fields, DBObject sort, int limit, int skip) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, fields, sort, limit, skip);
+  }
+  // job, uri, inputformat, mapper, query, fields, sort
+  public static void addInputPath(Job job, String uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  DBObject query, DBObject fields, DBObject sort) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, fields, sort, 0, 0);
+  }
+  public static void addInputPath(Job job, MongoURI uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  DBObject query, DBObject fields, DBObject sort) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, fields, sort, 0, 0);
+  }
+  // job, uri, inputformat, mapper, query, fields
+  public static void addInputPath(Job job, String uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  DBObject query, DBObject fields) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, fields, null, 0, 0);
+  }
+  public static void addInputPath(Job job, MongoURI uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  DBObject query, DBObject fields) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, fields, null, 0, 0);
+  }
+  public static void addInputPath(Job job, String uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  String query, String fields) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, fields, null, 0, 0);
+  }
+  public static void addInputPath(Job job, MongoURI uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  String query, String fields) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, fields, null, 0, 0);
+  }
+  // job, uri, inputformat, mapper, query
+  public static void addInputPath(Job job, String uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  DBObject query) {
+	  addInputPath(job, uri, inputFormatClass, mapperClass, query, null, null, 0, 0);
+  }
+  public static void addInputPath(Job job, MongoURI uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  DBObject query) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, null, null, 0, 0);
+  }
+  public static void addInputPath(Job job, String uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  String query) {
+	  addInputPath(job, uri, inputFormatClass, mapperClass, query, null, null, 0, 0);
+  }
+  public static void addInputPath(Job job, MongoURI uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass,
+		  String query) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, query, null, null, 0, 0);
+  }
+  // job, uri, inputformat, mapper
+  public static void addInputPath(Job job, String uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass) {
+	  addInputPath(job, uri.toString(), inputFormatClass, mapperClass, new BasicDBObject(), new BasicDBObject(), new BasicDBObject(), 0, 0);
+  }
+  public static void addInputPath(Job job, MongoURI uri, Class<? extends InputFormat> inputFormatClass, Class<? extends Mapper> mapperClass) {
+	  addInputPath(job, uri, inputFormatClass, mapperClass, null, null, null, 0, 0);
+  }
+  /**
+   * Retrieves a map of {@link Path}s to the {@link InputFormat} class
+   * that should be used for them.
+   * 
+   * @param job The {@link JobContext}
+   * @see #addInputPath(JobConf, Path, Class)
+   * @return A map of paths to inputformats for the job
+   */
+  @SuppressWarnings("unchecked")
+  static Map<Path, InputFormat> getInputFormatMap(JobContext job) {
+    Map<Path, InputFormat> m = new HashMap<Path, InputFormat>();
+    Configuration conf = job.getConfiguration();
+    
+    List<MongoRequest> mongoRequests = MongoConfigUtil.getMongoRequests(conf);
+    for (MongoRequest mongoRequest : mongoRequests) {
+      InputFormat inputFormat;
+      try {
+       inputFormat = (InputFormat) ReflectionUtils.newInstance(conf
+           .getClassByName(mongoRequest.getInputFormat()), conf);
+      } catch (ClassNotFoundException e) {
+       throw new RuntimeException(e);
+      }
+      m.put(new Path(mongoRequest.getInputURI().toString()), inputFormat);
+    }
+    return m;
+  }
+
+  /**
+   * Retrieves a map of {@link Path}s to the {@link Mapper} class that
+   * should be used for them.
+   * 
+   * @param job The {@link JobContext}
+   * @see #addInputPath(JobConf, Path, Class, Class)
+   * @return A map of paths to mappers for the job
+   */
+  @SuppressWarnings("unchecked")
+  static Map<Path, Class<? extends Mapper>> 
+      getMapperTypeMap(JobContext job) {
+    Configuration conf = job.getConfiguration();
+    List<MongoRequest> mongoRequests = MongoConfigUtil.getMongoRequests(conf);
+    if (mongoRequests == null) {
+      return Collections.emptyMap();
+    }
+    Map<Path, Class<? extends Mapper>> m = new HashMap<Path, Class<? extends Mapper>>();
+    for (MongoRequest mongoRequest : mongoRequests) {
+      Class<? extends Mapper> mapClass;
+      try {
+       mapClass = (Class<? extends Mapper>) conf.getClassByName(mongoRequest.getMapper());
+      } catch (ClassNotFoundException e) {
+       throw new RuntimeException(e);
+      }
+      m.put(new Path(mongoRequest.getInputURI().toString()), mapClass);
+    }
+    return m;
+  }
+  private static final Log log = LogFactory.getLog( MongoMultipleInputs.class );
+
+}

--- a/core/src/main/java/com/mongodb/hadoop/io/BSONWritable.java
+++ b/core/src/main/java/com/mongodb/hadoop/io/BSONWritable.java
@@ -187,7 +187,13 @@ public class BSONWritable implements BSONObject, WritableComparable {
         }
 
     }
-
+    /**
+     * {@inheritDoc}
+     */
+    public String toJSONString(){
+        return _doc.toString();
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoRequest.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoRequest.java
@@ -1,0 +1,104 @@
+package com.mongodb.hadoop.util;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.MongoURI;
+import com.mongodb.util.JSON;
+import com.mongodb.util.JSONParseException;
+
+public class MongoRequest {
+	private MongoURI mongoURI;
+	private DBObject query;
+	private DBObject fields;
+	private DBObject sort;
+	private int skip;
+	private int limit;
+	private String inputFormat;
+	private String mapper;
+	
+	public MongoRequest (String uri, String _inputFormat, String _mapper, String _query, String _fields, String _sort, int _skip, int _limit){
+		mongoURI = new MongoURI(uri);
+		inputFormat = _inputFormat;
+		mapper = _mapper;
+		query = (DBObject) JSON.parse(_query);
+		fields = (DBObject) JSON.parse(_fields);
+		sort = (DBObject) JSON.parse(_sort);
+		skip = _skip;
+		limit = _limit;
+	}
+
+	public MongoRequest (DBObject setting){
+		this((String) setting.get("uri"), 
+				setting.containsField("inputFormat") ? (String) setting.get("inputFormat") : null,
+				setting.containsField("mapper") ? (String) setting.get("mapper") : null,
+				setting.containsField("query") ? (String) setting.get("query") : null,
+				setting.containsField("fields") ? (String) setting.get("fields") : null,
+				setting.containsField("sort") ? (String) setting.get("sort") : null,
+				setting.containsField("skip") ? (int) Integer.valueOf((String) setting.get("skip")) : 0,
+				setting.containsField("limit") ? (int) Integer.valueOf((String) setting.get("limit")) : 0);
+	}
+
+	public MongoRequest (String setting) throws JSONParseException {
+		this((BasicDBObject) JSON.parse(setting));
+	}
+	
+	public String toString(){
+		String mongoRequest = 
+				mongoURI.toString() + ";" + inputFormat + ";" + mapper + ";" + query + ";" + fields + ";" + sort + ";" + skip + ";" + limit;
+		return mongoRequest;
+	}
+
+	public MongoURI getInputURI (){
+		return mongoURI;
+	}
+	public String getInputFormat (){
+		return inputFormat;
+	}
+	public String getMapper (){
+		return mapper;
+	}
+	public DBObject getQuery (){
+		return query;
+	}
+	public DBObject getFields (){
+		return fields;
+	}
+	public DBObject getSort (){
+		return sort;
+	}
+	public int getSkip (){
+		return skip;
+	}
+	public int getLimit (){
+		return limit;
+	}
+	
+	public void setInputURI (MongoURI uri){
+		mongoURI = uri;
+	}
+	public void setInputFormat (String _inputFormat){
+		inputFormat = _inputFormat;
+	}
+	public void setMapper (String _mapper){
+		mapper = _mapper;
+	}
+	public void setInputURI (String uri){
+		mongoURI = new MongoURI(uri);
+	}
+	public void setQuery (DBObject _query){
+		query = _query;
+	}
+	public void setFields (DBObject _fields){
+		fields = _fields;
+	}
+	public void setSort (DBObject _sort){
+		sort = _sort;
+	}
+	public void setSkip (int _skip){
+		skip = _skip;
+	}
+	public void setLimit (int _limit){
+		limit = _limit;
+	}
+
+}

--- a/core/src/main/java/org/apache/hadoop/mapreduce/lib/input/TaggedInputSplitGenerator.java
+++ b/core/src/main/java/org/apache/hadoop/mapreduce/lib/input/TaggedInputSplitGenerator.java
@@ -1,0 +1,14 @@
+package org.apache.hadoop.mapreduce.lib.input;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.Mapper;
+
+public class TaggedInputSplitGenerator {
+	public static TaggedInputSplit getTaggedInputSplit(InputSplit inputSplit, Configuration conf,
+		      Class<? extends InputFormat> inputFormatClass,
+		      Class<? extends Mapper> mapperClass){
+		return new TaggedInputSplit(inputSplit, conf, inputFormatClass, mapperClass);
+	}
+}

--- a/examples/treasury_yield/src/main/resources/mongo-treasury_yield.xml
+++ b/examples/treasury_yield/src/main/resources/mongo-treasury_yield.xml
@@ -18,12 +18,20 @@
   <property>
     <!-- If you are reading from mongo, the URI -->
     <name>mongo.input.uri</name>
+<<<<<<< HEAD
     <value>mongodb://127.0.0.1/mongo_hadoop.yield_historical.in</value>
+=======
+    <value>mongodb://127.0.0.1/demo.yield_historical.in</value>
+>>>>>>> develop/multipleinputs
   </property>
   <property>
     <!-- If you are writing to mongo, the URI -->
     <name>mongo.output.uri</name>
+<<<<<<< HEAD
     <value>mongodb://127.0.0.1/mongo_hadoop.yield_historical.out</value>
+=======
+    <value>mongodb://127.0.0.1/demo.yield_historical.out</value>
+>>>>>>> develop/multipleinputs
   </property>
   <property>
     <!-- The query, in JSON, to execute [OPTIONAL] -->

--- a/streaming/language_support/python/pymongo_hadoop/input.py
+++ b/streaming/language_support/python/pymongo_hadoop/input.py
@@ -5,8 +5,12 @@ import struct
 
 class BSONInput(object):
     """Custom file class for decoding streaming BSON,
+<<<<<<< HEAD
     based upon the Dumbo & "typedbytes" modules at
     https://github.com/klbostee/dumbo &
+=======
+    based upon the Dumbo "typedbytes" module at
+>>>>>>> develop/multipleinputs
     https://github.com/klbostee/typedbytes
     """
 

--- a/streaming/language_support/python/pymongo_hadoop/output.py
+++ b/streaming/language_support/python/pymongo_hadoop/output.py
@@ -4,9 +4,14 @@ from bson import BSON
 
 
 class BSONOutput(object):
+<<<<<<< HEAD
     """Custom file class for decoding streaming BSON,
     based upon the Dumbo & "typedbytes" modules at
     https://github.com/klbostee/dumbo &
+=======
+    """Custom file class for encoding streaming BSON,
+    based upon the Dumbo "typedbytes" module at
+>>>>>>> develop/multipleinputs
     https://github.com/klbostee/typedbytes
     """
 


### PR DESCRIPTION
feature: MongoMultipleInputs. This patch enables us set query, fields, sort, limit and skip to MongoURI for MultipleInputs

Conflicts:
    core/src/main/java/com/mongodb/hadoop/MongoConfig.java
    core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
    core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
    core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
    examples/pom.xml
    examples/treasury_yield/src/main/resources/mongo-treasury_yield.xml
    examples/world_development_indicators/src/main/resources/mongo-defaults.xml
    streaming/language_support/python/pymongo_hadoop/input.py
    streaming/language_support/python/pymongo_hadoop/output.py
    streaming/run.sh
    streaming/run_kv.sh
