### PR TITLE
MongoSplitter shouldn’t ignore authentication when connecting

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
@@ -40,15 +40,10 @@ public class MongoSplitter {
          * split; Actual querying will be done on the individual mappers.
          */
         MongoURI uri = conf.getInputURI();
-        Mongo mongo;
-        try {
-            mongo = uri.connect();
-        } catch (UnknownHostException e) {
-            throw new IllegalStateException( " Unable to connect to MongoDB at '" + uri + "'", e);
-        }
+        DBCollection coll = MongoConfigUtil.getCollection(uri);
+        DB db = coll.getDB(); 
+        Mongo mongo = db.getMongo();
 
-        DB db = mongo.getDB( uri.getDatabase() );
-        DBCollection coll = db.getCollection( uri.getCollection() );
         final CommandResult stats = coll.getStats();
         
         final boolean isSharded = stats.getBoolean( "sharded", false );


### PR DESCRIPTION
The current MongoSplitter’s way of connecting with uri.connect() calls the Mongo( MongoURI uri ) constructor which doesn’t support authentication.

This change simply delegates connection to MongoConfigUtil which also handles authentication.
