### PR TITLE
Made options optional for Pig MongoStorage()

### DIFF
--- a/pig/src/main/java/com/mongodb/hadoop/pig/MongoStorage.java
+++ b/pig/src/main/java/com/mongodb/hadoop/pig/MongoStorage.java
@@ -207,9 +207,11 @@ public class MongoStorage extends StoreFunc implements StoreMetadata {
             e.printStackTrace();
         }
         
-        // If we are insuring any indexes do so now:
-        for (MongoStorageOptions.Index in : options.getIndexes()) {
-            _recordWriter.ensureIndex(in.index, in.options);
+        if(options != null) {
+            // If we are insuring any indexes do so now:
+            for (MongoStorageOptions.Index in : options.getIndexes()) {
+                _recordWriter.ensureIndex(in.index, in.options);
+            }
         }
     }
 


### PR DESCRIPTION
Since the addition of options, MongoStorage() broke backwards compatibility in that it required options. This fixes that bug.
