### PR TITLE
Don't initialize cursor and encoder during constructor.  This improves p...

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
+++ b/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
@@ -49,9 +49,6 @@ public class MongoInputSplit extends InputSplit implements Writable {
         _limit = limit;
         _skip = skip;
         _notimeout = noTimeout;
-        getCursor();
-        getBSONDecoder();
-        getBSONEncoder();
     }
 
 

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoSplitter.java
@@ -300,6 +300,7 @@ public class MongoSplitter {
         try {
             int numChunks = 0;
             final int numExpectedChunks = cur.size();
+            MongoURI inputURI = conf.getInputURI();
 
             final List<InputSplit> splits = new ArrayList<InputSplit>( numExpectedChunks );
             while ( cur.hasNext() ){
@@ -329,8 +330,6 @@ public class MongoSplitter {
                 if ( log.isDebugEnabled() ){
                     log.debug( "[" + numChunks + "/" + numExpectedChunks + "] new query is: " + shardKeyQuery );
                 }
-
-                MongoURI inputURI = conf.getInputURI();
 
                 if ( useShards ){
                     final String shardname = row.getString( "shard" );


### PR DESCRIPTION
...erformance of input split calculation.
Calling getCursor() in the constructor for every split is slow, especially when auth is enabled.  getCursor subsequently calls MongoConfigUtil.getCollection() which in the case of an authenticated cluster, causes an authentication to happen for each split.  In an example case of 572 splits, calculation of splits went from 20-30 seconds to < 1 second.  The eager loading of the cursor seems pointless anyway, since the splits are serialized out to the processing nodes before any records are pulled.
