### PR TITLE
Use the DBCursor addSpecial when doing .  This is in support of the Mong...

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
+++ b/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
@@ -138,7 +138,19 @@ public class MongoInputSplit extends InputSplit implements Writable {
         // them.
         // todo - support limit/skip
         if ( _cursor == null ){
-            _cursor = MongoConfigUtil.getCollection( _mongoURI ).find( _querySpec, _fieldSpec ).sort( _sortSpec );
+            if (_querySpec.containsKey("$query")) {
+                _cursor = MongoConfigUtil.getCollection( _mongoURI ).find( null, _fieldSpec );
+                for (String key : _querySpec.keySet()) {
+                    _cursor.addSpecial( key, _querySpec.get( key ) );
+                }
+            } else {
+                _cursor = MongoConfigUtil.getCollection( _mongoURI ).find( _querySpec, _fieldSpec );
+            }
+            _cursor = _cursor.sort( _sortSpec );
+
+            if (_skip > 0) {
+                _cursor.skip(_skip);
+            }
             if (_notimeout) _cursor.setOptions( Bytes.QUERYOPTION_NOTIMEOUT );
             _cursor.slaveOk();
         }


### PR DESCRIPTION
...o Java driver 2.9.0, which breaks the current logic because of the addition of readPreferences to the query.  There may be a prettier way of determining to use specials.
