### PR TITLE
Pig 0.11 new datetime type support for MongoLoader

### DIFF
--- a/pig/src/main/java/com/mongodb/hadoop/pig/MongoLoader.java
+++ b/pig/src/main/java/com/mongodb/hadoop/pig/MongoLoader.java
@@ -23,14 +23,15 @@ import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.util.Utils;
-//import org.apache.pig.parser.ParserException;
 import org.bson.BSONObject;
+import org.joda.time.DateTime;
 
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.hadoop.MongoInputFormat;
 import com.mongodb.hadoop.input.MongoRecordReader;
 import com.mongodb.hadoop.util.MongoConfigUtil;
+//import org.apache.pig.parser.ParserException;
 
 public class MongoLoader extends LoadFunc implements LoadMetadata {
 	private static final Log log = LogFactory.getLog( MongoStorage.class );
@@ -108,6 +109,8 @@ public class MongoLoader extends LoadFunc implements LoadMetadata {
     			return obj;
     		case DataType.CHARARRAY:
     			return obj.toString();
+    		case DataType.DATETIME:
+    		    return new DateTime(obj);
     		case DataType.TUPLE:
     			ResourceSchema s = field.getSchema();
     			ResourceFieldSchema[] fs = s.getFields();

--- a/pig/src/test/java/com/mongodb/hadoop/pig/MongoLoaderTest.java
+++ b/pig/src/test/java/com/mongodb/hadoop/pig/MongoLoaderTest.java
@@ -5,11 +5,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.Tuple;
+import org.joda.time.DateTime;
 import org.junit.Test;
 
 import com.mongodb.BasicDBList;
@@ -33,6 +36,20 @@ public class MongoLoaderTest {
 
         Object result = ml.readField(1.1F, ml.fields[0]);
         assertEquals(1.1F, result);
+    }
+    
+    @Test
+    public void testReadField_simpleDate() throws IOException {
+        String userSchema = "d:datetime";
+        MongoLoader ml = new MongoLoader(userSchema);
+        
+        Calendar calendar = Calendar.getInstance();
+        // the Mongo Java driver returns a java.util.Date for ISODate objects
+        // therefore this should be safe
+        Date in = calendar.getTime();
+        DateTime out = new DateTime(in);
+        Object result = ml.readField(in, ml.fields[0]);
+        assertEquals(out, result);
     }
     
     @Test


### PR DESCRIPTION
Adds support + test for the new datetime data type introduced in Pig 0.11 to MongoLoader