### PR TITLE
Added Lazy BSON as a input type

### DIFF
--- a/BSON_README.md
+++ b/BSON_README.md
@@ -56,3 +56,4 @@ If you intend to feed this output .bson file into subsequent jobs, you can gener
 * `bson.split.write_splits` - Automatically save any split information calculated for input files, by writing to corresponding `.splits` files. Defaults to `true`.
 * `bson.output.build_splits` - Build a `.splits` file on the fly when constructing an output .BSON file. Defaults to `false`.
 * `bson.pathfilter.class` - Set the class name for a `[PathFilter](http://hadoop.apache.org/docs/current/api/org/apache/hadoop/fs/PathFilter.html)` to filter which files to process when scanning directories for bson input files. Defaults to `null` (no additional filtering). You can set this value to `com.mongodb.hadoop.BSONPathFilter` to restrict input to only files ending with the ".bson" extension.
+* `mongo.input.lazy_bson` - True to indicate using LazyBSONObject as input to Mapper, false will utilize BasicBSONObject.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -52,6 +52,9 @@ specify an output collection URI to write the output to. If using a sharded clus
 #####`mongo.input.notimeout` 
 Set notimeout on the cursor when reading each split. This can be necessary if really large splits are being truncated because cursors are killed before all the data has been read.
 
+#####`mongo.input.lazy_bson`
+Defaults to false, which will decode the BSON docs into BasicBSONObjects for Mapper. True will decode docs into LazyBSONObjects.  
+
 #####`mongo.input.split.use_range_queries`
 
 This setting causes data to be read from mongo by adding `$gte/$lt` clauses to the query for limiting the boundaries of each split, instead of the default behavior of limiting with `$min/$max`. This may be useful in cases when using `mongo.input.query` is being used to filter mapper input, but the index that would be used by `$min/$max` is less selective than the query and indexes. Setting this to `'true'` lets the MongoDB server select the best index possible and still. This defaults to '`false'` if not set.

--- a/core/src/main/java/com/mongodb/hadoop/MongoConfig.java
+++ b/core/src/main/java/com/mongodb/hadoop/MongoConfig.java
@@ -278,6 +278,14 @@ public class MongoConfig {
         MongoConfigUtil.setSkip( _conf, skip );
     }
 
+    public boolean getLazyBSON(){
+        return MongoConfigUtil.getLazyBSON( _conf );
+    }
+
+    public void setLazyBSON( boolean lazy ){
+        MongoConfigUtil.setLazyBSON( _conf, lazy) ;
+    }
+
     public int getSplitSize(){
         return MongoConfigUtil.getSplitSize( _conf );
     }

--- a/core/src/main/java/com/mongodb/hadoop/mapred/input/BSONFileRecordReader.java
+++ b/core/src/main/java/com/mongodb/hadoop/mapred/input/BSONFileRecordReader.java
@@ -18,6 +18,7 @@ package com.mongodb.hadoop.mapred.input;
 
 import com.mongodb.hadoop.io.BSONWritable;
 import com.mongodb.hadoop.util.BSONLoader;
+import com.mongodb.hadoop.util.MongoConfigUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -52,8 +53,8 @@ public class BSONFileRecordReader implements RecordReader<NullWritable, BSONWrit
     private int numDocsRead = 0;
     private boolean finished = false;
 
-    BasicBSONCallback callback = new BasicBSONCallback();
-    BasicBSONDecoder decoder = new BasicBSONDecoder();
+    private BSONCallback callback;
+    private BSONDecoder decoder;
 
     public BSONFileRecordReader(){ }
 
@@ -64,6 +65,13 @@ public class BSONFileRecordReader implements RecordReader<NullWritable, BSONWrit
         FileSystem fs = file.getFileSystem(conf);
         in = fs.open(file, 16*1024*1024);
         in.seek(fileSplit.getStart());
+        if (MongoConfigUtil.getLazyBSON(conf)) {
+            callback = new LazyBSONCallback();
+            decoder = new LazyBSONDecoder();
+        } else {
+            callback = new BasicBSONCallback();
+            decoder = new BasicBSONDecoder();
+        }
     }
 
     @Override

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
@@ -82,6 +82,7 @@ public class MongoConfigUtil {
     public static final String INPUT_SORT = "mongo.input.sort";
     public static final String INPUT_LIMIT = "mongo.input.limit";
     public static final String INPUT_SKIP = "mongo.input.skip";
+    public static final String INPUT_LAZY_BSON = "mongo.input.lazy_bson";
 
 
     //Settings specific to bson reading/writing.
@@ -529,6 +530,14 @@ public class MongoConfigUtil {
 
     public static void setSkip( Configuration conf, int skip ){
         conf.setInt( INPUT_SKIP, skip );
+    }
+
+    public static boolean getLazyBSON( Configuration conf ){
+        return conf.getBoolean(INPUT_LAZY_BSON, false);
+    }
+
+    public static void setLazyBSON( Configuration conf, boolean lazy ){
+        conf.setBoolean(INPUT_LAZY_BSON, lazy);
     }
 
     public static int getSplitSize( Configuration conf ){


### PR DESCRIPTION
Speeds (this is all compared with mongo-hadoop master, BSONComparator isn't
included):

enron:
    Original (mongodb/mongo-hadoop/master) - 62.63s
    lazyBSON = false (Code added, option set to false) - 65.45s
    lazyBSON = true (Code added, option set to true) - 64.13s

PageRank 1 iteration:
    Original (mongodb/mongo-hadoop/master) - 
        823779 milliseconds = 13.7296 minutes
    lazyBSON = true (Code added, option set to true) - 
        611790 milliseconds = 10.1965 minutes
