### PR TITLE
Fixed package of BSONFileInputFormat

### DIFF
--- a/hive/README.md
+++ b/hive/README.md
@@ -1,12 +1,11 @@
-
 CREATE TABLE scores ( student int, name string, score int ) ROW FORMAT SERDE "com.mongodb.hadoop.hive.BSONSerde"
-STORED AS INPUTFORMAT "com.mongodb.hadoop.BSONFileInputFormat"
+STORED AS INPUTFORMAT "com.mongodb.hadoop.mapred.BSONFileInputFormat"
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';
 
 LOAD DATA LOCAL INPATH "<FULL_WORKING_DIR>/src/test/resources/scores/scores.bson" INTO TABLE scores;
 
 CREATE TABLE books ( author array<string>, edition string, isbn string,   publicationYear int, publisher string, tags array<string>, title string ) ROW FORMAT SERDE "com.mongodb.hadoop.hive.BSONSerde"
-STORED AS INPUTFORMAT "com.mongodb.hadoop.hive.input.BSONFileInputFormat"
+STORED AS INPUTFORMAT "com.mongodb.hadoop.mapred.BSONFileInputFormat"
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';
 
 LOAD DATA LOCAL INPATH "<FULL_WORKING_DIR>/src/test/resources/books/books.bson" INTO TABLE books;


### PR DESCRIPTION
`com.mongodb.hadoop.BSONFileInputFormat` uses `org.apache.hadoop.mapreduce.lib.input.FileInputFormat`, while it should use `org.apache.hadoop.mapred.InputFormat`.

(Hive does not have an implementation of the "new" API in `org.apache.hadoop.mapreduce`)
