### PR TITLE
BSONWritable is not a BSONObject anymore

### DIFF
--- a/hive/src/main/java/com/mongodb/hadoop/hive/BSONSerde.java
+++ b/hive/src/main/java/com/mongodb/hadoop/hive/BSONSerde.java
@@ -129,7 +129,7 @@ public class BSONSerde implements SerDe {
         if (blob instanceof BSONWritable) {
             BSONWritable b = (BSONWritable) blob;
             LOG.debug("Got a BSONWritable: " + b);
-            doc = (BSONObject) b;
+            doc = b.getDoc();
         } else {
             throw new SerDeException(getClass().toString() +
                     " requires a BSONWritable object, not " + blob.getClass());


### PR DESCRIPTION
Bug introduced by c905d6cbac44df90bc05bc9822ea0ceaac2b4a72
