### PR TITLE
Add compression support to BSONFileInputFormat.

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/input/BSONFileRecordReader.java
+++ b/core/src/main/java/com/mongodb/hadoop/input/BSONFileRecordReader.java
@@ -30,6 +30,12 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.fs.Seekable;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.io.compress.CodecPool;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.io.compress.CompressionCodec;
+
 import org.bson.*;
 
 import java.io.DataInputStream;
@@ -65,22 +71,41 @@ public class BSONFileRecordReader extends RecordReader<NullWritable, BSONObject>
     private Object key;
     private BSONObject value;
     byte[] headerBuf = new byte[4];
-    private FSDataInputStream in;
+    private InputStream in;
     private int numDocsRead = 0;
     private boolean finished = false;
 
     private BSONCallback callback;
     private BSONDecoder decoder;
 
+    private CompressionCodecFactory compressionCodecs = null;
+    private CompressionCodec codec;
+    private Decompressor decompressor;
+    private Seekable filePosition;
     @Override
     public void initialize(InputSplit inputSplit, TaskAttemptContext context) throws IOException, InterruptedException {
         this.fileSplit = (FileSplit) inputSplit;
         this.conf = context.getConfiguration();
-        log.info("reading split " + this.fileSplit.toString());
         Path file = fileSplit.getPath();
+        compressionCodecs = new CompressionCodecFactory(this.conf);
+        codec = compressionCodecs.getCodec(file);
         FileSystem fs = file.getFileSystem(conf);
-        in = fs.open(file, 16*1024*1024);
-        in.seek(fileSplit.getStart());
+        FSDataInputStream fileIn = fs.open(file, 16*1024*1024);
+        if (codec == null) {
+            log.info("reading split " + this.fileSplit.toString());
+            fileIn.seek(fileSplit.getStart());
+            in = fileIn;
+        } else {
+            if (fileSplit.getStart() > 0) {
+                throw new IOException("File is not seekable but start of split is non-zero");
+            }
+            decompressor = CodecPool.getDecompressor(codec);
+            in = codec.createInputStream(fileIn, decompressor);
+            log.info("reading compressed split " + this.fileSplit.toString());
+            // start is ignored. as the file is not really seekable.
+            // but then the splits should be starting at 0
+        }
+        filePosition = fileIn;
 
         if (MongoConfigUtil.getLazyBSON(this.conf)) {
             callback = new LazyBSONCallback();
@@ -94,7 +119,8 @@ public class BSONFileRecordReader extends RecordReader<NullWritable, BSONObject>
     @Override
     public boolean nextKeyValue() throws IOException, InterruptedException {
         try{
-            if(in.getPos() >= this.fileSplit.getStart() + this.fileSplit.getLength()){
+            if (filePosition.getPos() >= this.fileSplit.getStart() + this.fileSplit.getLength()
+                    && (codec == null || in.available() == 0)) {
                 try{
                     this.close();
                 }catch(Exception e){
@@ -108,7 +134,7 @@ public class BSONFileRecordReader extends RecordReader<NullWritable, BSONObject>
             value = (BSONObject) callback.get();
             numDocsRead++;
             if(numDocsRead % 10000 == 0){
-                log.debug("read " + numDocsRead + " docs from " + this.fileSplit.toString() + " at " + in.getPos());
+                log.debug("read " + numDocsRead + " docs from " + this.fileSplit.toString() + " at " + filePosition.getPos());
             }
             return true;
         }catch(Exception e){
@@ -138,7 +164,7 @@ public class BSONFileRecordReader extends RecordReader<NullWritable, BSONObject>
         if(this.finished)
             return 1f;
         if(in != null)
-            return new Float(in.getPos() - this.fileSplit.getStart()) / this.fileSplit.getLength();
+            return new Float(filePosition.getPos() - this.fileSplit.getStart()) / this.fileSplit.getLength();
         return 0f;
     }
 
@@ -147,6 +173,9 @@ public class BSONFileRecordReader extends RecordReader<NullWritable, BSONObject>
         this.finished = true;
         if(this.in != null){
             in.close();
+        }
+        if (codec != null){
+            ((FSDataInputStream)this.filePosition).close();
         }
     }
 


### PR DESCRIPTION
- Prevent BSONSplitter to try to split compressed files.
- BSONFileRecordReader detects whether a file is compressed, and if so,
  use the proper codec. This code is heavily inspired for the one from
  TextInputFormat.
