### PR TITLE
Fail fast in MongoSplitterFactory if retrieving collection stats failed.

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/splitter/MongoSplitterFactory.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/MongoSplitterFactory.java
@@ -76,6 +76,10 @@ public class MongoSplitterFactory{
                 coll = MongoConfigUtil.getCollection(uri);
                 stats = coll.getStats();
             }
+            
+            if (!stats.getBoolean( "ok", false )) {
+                throw new RuntimeException( "Unable to calculate input splits from collection stats: " + stats.getString( "errmsg" ) );
+            }
 
             final boolean isSharded = stats.getBoolean( "sharded", false );
             if(!isSharded){


### PR DESCRIPTION
When checking the stats on the collection, ensure that the stats call was successful before attempting to use its return values.
For example if auth failed on a sharded collection, it would have returned a StandaloneMongoSplitter which doesn't make it immediately obvious what went wrong.
