### PR TITLE
Add shebang (#!) line to bson_splitter.py

### DIFF
--- a/tools/bson_splitter.py
+++ b/tools/bson_splitter.py
@@ -1,4 +1,4 @@
-#!/bin/env python2
+#!/bin/env python
 import sys
 import struct
 import pymongo


### PR DESCRIPTION
Allow the script to be run with `./bson_splitter.py`
