### PR TITLE
Fixes BSONStorage handling of a null map

### DIFF
--- a/pig/src/main/java/com/mongodb/hadoop/pig/BSONStorage.java
+++ b/pig/src/main/java/com/mongodb/hadoop/pig/BSONStorage.java
@@ -137,7 +137,9 @@ public class BSONStorage extends StoreFunc implements StoreMetadata {
 
                 return a;
             case DataType.MAP:
-                Map map = (Map) o;
+            	if (o == null)
+                	return o;
+                Map map = (Map) o;                                
                 Map<String,Object> out = new HashMap<String,Object>(map.size());
                 for(Object key : map.keySet()) {
                     out.put(key.toString(), getTypeForBSON(map.get(key), null));

--- a/pig/src/test/java/com/mongodb/hadoop/pig/BSONStorageTest.java
+++ b/pig/src/test/java/com/mongodb/hadoop/pig/BSONStorageTest.java
@@ -1,0 +1,24 @@
+package com.mongodb.hadoop.pig;
+
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+
+import java.util.Map;
+
+import org.apache.pig.ResourceSchema;
+import org.apache.pig.impl.util.Utils;
+
+
+public class BSONStorageTest {
+	@Test
+    public void testGetTypeForBSON_map_null() throws Exception {
+        BSONStorage bs = new BSONStorage();
+        ResourceSchema schema = new ResourceSchema(Utils.getSchemaFromString("m:map[]"));
+        
+        Map val = null;
+
+        Object out = bs.getTypeForBSON(val, schema);
+        
+        assertNull(out);
+    }
+}


### PR DESCRIPTION
BSONStorage throws NullPointerException if input for getTypeForBSON is a null object but schema is of a map.
