### PR TITLE
HADOOP-109 Fix multi-collection input example.

### DIFF
--- a/examples/treasury_yield/src/main/java/com/mongodb/hadoop/examples/treasury/TreasuryYieldMulti.java
+++ b/examples/treasury_yield/src/main/java/com/mongodb/hadoop/examples/treasury/TreasuryYieldMulti.java
@@ -48,15 +48,15 @@ public class TreasuryYieldMulti extends MongoTool {
                  (DBObject) null, // sort
                  (DBObject) null, // query
                  false,
-                 MultiMongoCollectionSplitter.class)
-            .add(new MongoURI("mongodb://localhost:27017/mongo_hadoop.yield_historical.in"),
-                 (MongoURI) null, // authuri
-                 true, // notimeout
-                 (DBObject) null, // fields
-                 (DBObject) null, // sort
-                 new BasicDBObject("_id", new BasicDBObject("$gt", new Date(883440000000L))),
-                 false, // range query
-                 MultiMongoCollectionSplitter.class);
+                 null // splitter class, null will let Hadoop-Connector decide.
+        ).add(new MongoURI("mongodb://localhost:27017/mongo_hadoop.yield_historical.in"),
+                (MongoURI) null, // authuri
+                true, // notimeout
+                (DBObject) null, // fields
+                (DBObject) null, // sort
+                new BasicDBObject("_id", new BasicDBObject("$gt", new Date(883440000000L))),
+                false, // range query
+                null);
 
         Configuration conf = new Configuration();
         conf.set(MultiMongoCollectionSplitter.MULTI_COLLECTION_CONF_KEY, mcsb.toJSON());


### PR DESCRIPTION
Splitter classes other than `MultiMongoCollectionSplitter` could be given for inputs, but [HADOOP-110](https://jira.mongodb.org/browse/HADOOP-110) prevents us from doing that. So we use `null` to let Hadoop-Connector decide.
