### PR TITLE
Fix NPE in BSONSerDe

### DIFF
--- a/hive/src/main/java/com/mongodb/hadoop/hive/BSONSerDe.java
+++ b/hive/src/main/java/com/mongodb/hadoop/hive/BSONSerDe.java
@@ -475,11 +475,11 @@ public class BSONSerDe implements SerDe {
     private Object serializeList(final Object obj, final ListObjectInspector oi, final String ext) {
         BasicBSONList list = new BasicBSONList();
         List<?> field = oi.getList(obj);
-        
+
         if (field == null) {
             return list;
         }
-        
+
         ObjectInspector elemOI = oi.getListElementObjectInspector();
 
         for (Object elem : field) {
@@ -593,6 +593,9 @@ public class BSONSerDe implements SerDe {
         switch (oi.getPrimitiveCategory()) {
             case TIMESTAMP:
                 Timestamp ts = (Timestamp) oi.getPrimitiveJavaObject(obj);
+                if (ts == null) {
+                    return null;
+                }
                 return new Date(ts.getTime());
             default:
                 return oi.getPrimitiveJavaObject(obj);


### PR DESCRIPTION
This would fail with a NPE when a source List was null. This fixes it by returning an empty list.

The other alternative is to return null but that does set the field in MongoDB to null. I'm not sure what the best practices are in the MongoDB community but I'd think that instead of storing an explicit null I'd just leave out the field all-together.
