### PR TITLE
New signature for MongoConfigUtil.setOutputURI() that takes MongoClientURI

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
@@ -451,7 +451,10 @@ public final class MongoConfigUtil {
     public static void setOutputURI(final Configuration conf, final String uri) {
         setMongoURIString(conf, OUTPUT_URI, uri);
     }
-
+     /**
+     * @deprecated use {@link #setOutputURI(Configuration, MongoClientURI)} instead
+     */
+    @Deprecated
     public static void setOutputURI(final Configuration conf, final MongoURI uri) {
         setMongoURI(conf, OUTPUT_URI, uri);
     }


### PR DESCRIPTION
`setInputURI()` has a signature that takes a `MongoClientURI`, but `setOutputURI()` only has a signature that takes the deprecated `MongoURI`.  This PR fixes that.

NOTE the `setInputURI()` signature that takes `MongoURI` is marked as deprecated.  Should I also deprecate the corresponding `setOutputURI()` signature?
## Test results

Tests fail for me on master, so the fact that they fail on this branch doesn't mean anything.  This change seems unlikely to break anything.

[jks@jks-desktop master /mnt/space/home/jks/work/mongo/mongo-hadoop]{f20}$ ./gradlew check
Building against hadoop 2.4 using 2.4.0 libraries
Checking if /home/jks/hadoop-binaries/hadoop-2.4.0/bin exists
:compileJava UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:compileTestJava UP-TO-DATE
:processTestResources UP-TO-DATE
:testClasses UP-TO-DATE
:test UP-TO-DATE
:check UP-TO-DATE
:core:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
:core:processResources UP-TO-DATE
:core:classes
:core:checkstyleMain
:core:compileTestJava
:core:processTestResources UP-TO-DATE
:core:testClasses
:core:checkstyleTest UP-TO-DATE
:core:findbugsMain FAILED

FAILURE: Build failed with an exception.
- What went wrong:
  Execution failed for task ':core:findbugsMain'.
  
  > FindBugs encountered an error. Run with --debug to get more information.
- Try:
  Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 26.831 secs
