### PR TITLE
Add capability of BSONLoader.java to parse UUID

### DIFF
--- a/pig/src/main/java/com/mongodb/hadoop/pig/BSONLoader.java
+++ b/pig/src/main/java/com/mongodb/hadoop/pig/BSONLoader.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class BSONLoader extends LoadFunc {
 
@@ -199,6 +200,8 @@ public class BSONLoader extends LoadFunc {
         } else if (o instanceof Date) {
             return ((Date) o).getTime();
         } else if (o instanceof ObjectId) {
+            return o.toString();
+        } else if (o instanceof UUID) {
             return o.toString();
         } else if (o instanceof BasicBSONList) {
             BasicBSONList bl = (BasicBSONList) o;


### PR DESCRIPTION
If the type of the object passed to convertBSONtoPigType is a UUID it is not recognised; the method defaults to outputting the object and breaking pig. If the type is objectId where the semantics are similar, the method already calls toString() on the object. This change just adds similar ability to the UUID object.

For further information see:

http://stackoverflow.com/questions/17579027/pig-mongoloader-exception-loading-data-with-uuids/21391717#21391717