### PR TITLE
com.mongodb.hadoop.hive.BSONSerde.getValue: supporting quoted dots

### DIFF
--- a/hive/src/main/java/com/mongodb/hadoop/hive/BSONSerDe.java
+++ b/hive/src/main/java/com/mongodb/hadoop/hive/BSONSerDe.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.hadoop.hive;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.hadoop.io.BSONWritable;
 import com.mongodb.util.JSON;
 import org.apache.commons.logging.Log;
@@ -55,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 
@@ -217,15 +219,14 @@ public class BSONSerDe implements SerDe {
         return row;
     }
 
-    private Object getValue(final BSONObject doc, final String mongoMapping) {
-        if (mongoMapping.contains(".")) {
-            int index = mongoMapping.indexOf('.');
-            BSONObject object = (BSONObject) doc.get(mongoMapping.substring(0, index));
-            return getValue(object, mongoMapping.substring(index + 1));
-        }
-        return doc.get(mongoMapping);
+    @VisibleForTesting
+    Object getValue(final BSONObject doc, final String mongoMapping) {
+        Object res = doc;
+        String[] mappings = mongoMapping.split("(?<!\\\\)" + Pattern.quote("."));
+        for (String mapping: mappings)
+          res = ((BSONObject) res).get(mapping.replace("\\.", "."));
+        return res;
     }
-
 
     /**
      * For a given Object value and its supposed TypeInfo determine and return its Hive object representation

--- a/hive/src/test/java/com/mongodb/hadoop/hive/BSONSerDeTest.java
+++ b/hive/src/test/java/com/mongodb/hadoop/hive/BSONSerDeTest.java
@@ -17,6 +17,7 @@ import org.bson.types.BasicBSONList;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
+import java.lang.reflect.Method;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
@@ -330,5 +331,22 @@ public class BSONSerDeTest {
 
         Object serialized = serde.serialize(obj, oi);
         assertThat(new BSONWritable(bObject), equalTo(serialized));
+    }
+
+    @Test
+    public void testKeyWithDot() throws SerDeException {
+        BasicBSONObject value = new BasicBSONObject();
+        BasicBSONObject nested = new BasicBSONObject();
+        nested.put("simple", 10);
+        nested.put("with.dot", 20);
+        value.put("simple", 30);
+        value.put("with.dot", 40);
+        value.put("nested", nested);
+
+        BSONSerDe serde = new BSONSerDe();
+        assertThat((Integer)serde.getValue(value, "simple"), equalTo(30));
+        assertThat((Integer)serde.getValue(value, "with\\.dot"), equalTo(40));
+        assertThat((Integer)serde.getValue(value, "nested.simple"), equalTo(10));
+        assertThat((Integer)serde.getValue(value, "nested.with\\.dot"), equalTo(20));
     }
 }


### PR DESCRIPTION
I am using a legacy BSON: using dot characters for some keys.
But this library does not supports this, so I implemented 'quoted dot.'

I tested this feature in my aws ami 3.1.0 & spark 1.0.0 & shark 0.9.0.
My testing query for the shark is:

``` sql
DROP TABLE test_external;

CREATE EXTERNAL TABLE test_external(
  my_data STRING
)
ROW FORMAT SERDE "com.mongodb.hadoop.hive.BSONSerDe"
WITH SERDEPROPERTIES('mongo.columns.mapping'='{"my_data":"my\\\\.data"}')
STORED AS INPUTFORMAT "com.mongodb.hadoop.mapred.BSONFileInputFormat"
OUTPUTFORMAT "com.mongodb.hadoop.hive.output.HiveBSONFileOutputFormat"
LOCATION '/data'
;

SELECT my_data FROM test_external ORDER BY my_data LIMIT 1;
```
