### PR TITLE
Fix MongoUpdateWritable serialization

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/io/MongoUpdateWritable.java
+++ b/core/src/main/java/com/mongodb/hadoop/io/MongoUpdateWritable.java
@@ -94,10 +94,10 @@ public class MongoUpdateWritable implements Writable {
         enc.set(buf);
         enc.putObject(this.query);
         enc.done();
-        buf.pipe(out);
         enc.set(buf);
         enc.putObject(this.modifiers);
         enc.done();
+        buf.pipe(out);
         out.writeBoolean(this.upsert);
         out.writeBoolean(this.multiUpdate);
     }

--- a/core/src/test/java/com/mongodb/hadoop/io/MongoUpdateWritableTest.java
+++ b/core/src/test/java/com/mongodb/hadoop/io/MongoUpdateWritableTest.java
@@ -1,0 +1,48 @@
+package com.mongodb.hadoop.io;
+
+import com.mongodb.BasicDBObject;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: bpfoster
+ * Date: 7/11/14
+ * Time: 8:41 PM
+ */
+public class MongoUpdateWritableTest {
+    @Test
+    public void testSerialization() throws Exception {
+        BasicDBObject query = new BasicDBObject("_id", new ObjectId());
+        BasicDBObject modifiers = new BasicDBObject("$set", new BasicDBObject("foo", "bar"));
+        MongoUpdateWritable writable = new MongoUpdateWritable(query, modifiers, true, false);
+
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
+
+        writable.write(out);
+
+        baos.flush();
+        byte[] serializedBytes = baos.toByteArray();
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(serializedBytes);
+        DataInputStream in = new DataInputStream(bais);
+
+        writable = new MongoUpdateWritable(null, null, false, true);
+
+        writable.readFields(in);
+
+        assertEquals(query, writable.getQuery());
+        assertEquals(modifiers, writable.getModifiers());
+        assertTrue(writable.isUpsert());
+        assertFalse(writable.isMultiUpdate());
+    }
+}


### PR DESCRIPTION
`readFields` would catch an exception during read -

> INFO  [main] io.MongoUpdateWritable (MongoUpdateWritable.java:readFields(135)) - No Length Header available.java.io.EOFException

because `write` had only actually written out the query and not the modifiers as well.
