### PR TITLE
BSONLoader has trouble with highly nested Mongo documents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ configure(subprojects) {
         testCompile 'org.zeroturnaround:zt-exec:1.6'
         testCompile 'com.jayway.awaitility:awaitility:1.6.0'
         testCompile 'commons-daemon:commons-daemon:1.0.15'
+        testCompile 'org.easymock:easymock:3.2'
 
         testCompile "org.apache.hadoop:hadoop-hdfs:${hadoopVersion}"
         testCompile "org.apache.hadoop:hadoop-hdfs:${hadoopVersion}:tests"

--- a/pig/src/main/java/com/mongodb/hadoop/pig/BSONLoader.java
+++ b/pig/src/main/java/com/mongodb/hadoop/pig/BSONLoader.java
@@ -1,7 +1,5 @@
 package com.mongodb.hadoop.pig;
 
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
 import com.mongodb.hadoop.BSONFileInputFormat;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/pig/src/test/java/com/mongodb/hadoop/pig/BSONLoaderTest.java
+++ b/pig/src/test/java/com/mongodb/hadoop/pig/BSONLoaderTest.java
@@ -1,0 +1,66 @@
+package com.mongodb.hadoop.pig;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.pig.data.Tuple;
+import org.bson.BasicBSONObject;
+import org.bson.types.BasicBSONList;
+import org.bson.types.ObjectId;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+public class BSONLoaderTest {
+    
+    @Test
+    public void testSimpleObject() throws Exception {
+        
+        String schema = "id:chararray,"
+        		      + "name:chararray,"
+        		      + "books:bag{tuple(title:chararray)}";
+        /*
+           This goal of this test is to pass an instance of BasicBSONObject,
+           NOT it's child BasicDBObject, to the BSONLoader class. It's possible
+           to do the following
+           
+               // Creates a BasicDBObject which we don't want
+               BasicBSONObject topLevelObject = (BasicBSONObject) JSON.parse(jsonDataStr);
+               
+           yet this creates a BasicDBObject under the hood. This is why the
+           following BSONobject is constructed long hand below.
+           
+           Test BSON object:
+                {"_id" : ObjectId("53ea61edc2e62b61021c2f2e"),
+                 "name" : "Jane",
+                 "books": [{"title":"Lord of the Rings"}]
+                }
+        */
+        BasicBSONObject book1 = new BasicBSONObject();
+        book1.append("title", "Lord of the Rings");
+        BasicBSONList bookList = new BasicBSONList();
+        bookList.add(book1);
+        BasicBSONObject simpleObject = new BasicBSONObject();
+        simpleObject.append("_id", new ObjectId(DatatypeConverter.parseHexBinary("53ea61edc2e62b61021c2f2e")));
+        simpleObject.append("name", "Jane");
+        simpleObject.append("books", bookList);
+ 
+        RecordReader recordReader = EasyMock.createNiceMock(RecordReader.class);
+        expect(recordReader.nextKeyValue()).andReturn(true).once();
+        expect(recordReader.nextKeyValue()).andReturn(false);
+        expect(recordReader.getCurrentValue()).andReturn(simpleObject).once();
+        expect(recordReader.getCurrentValue()).andReturn(null);
+        replay(recordReader);
+     
+        BSONLoader bsonLoader = new BSONLoader("id", schema);
+        bsonLoader.prepareToRead(recordReader, null);
+        Tuple t = bsonLoader.getNext();
+        
+        String expected = "(53ea61edc2e62b61021c2f2e,Jane,{(Lord of the Rings)})";
+        assertEquals(expected, t.toString());
+    }
+    
+}


### PR DESCRIPTION
I encountered problems using the BSONLoader to read highly nested Mongo documents. 

For example,

``` javascript
myPigRelation = LOAD '/data/mydata.bson' USING com.mongodb.hadoop.pig.BSONLoader(
'id',
'id:chararray,
 var1:chararray,
 var2:tuple(
   mySub1:bag{tuple(id:int, pos:int, app:int, fav:chararray)},
   mySub2:bag{tuple(id:int, sp:int, pos:int, app:int, fav:chararray)},
   mySub3:bag{tuple(id:int,sp:int, pos:int, app:int, fav:chararray)},
   mySub4:bag{tuple(id:chararray, pos:int, app:int, fav:chararray)},
   mySub5:bag{tuple(id:int, sport:int, pos:int, app:int, fav:chararray)},
   mySub6:bag{tuple(id:chararray, value:chararray, app:int)},
   mySub7:bag{tuple(id:int, type:chararray, text:chararray, app:int,
                    metadata:bag{tuple(name:chararray, value:chararray, pos:int)}
   )},
   mySub8:bag{tuple(id:int, app:int, pos:int)} 
 ),
 var3:tuple(avatars:bag{tuple(url:chararray, type:int, approved:chararray)})'
);
```

The changes contained herein resolved the problem for me. The presence of the BasicDBObject & BasicDBList rather than BasicBSONObject and BasicBSONList seem like a mistake to me, yet my confidence is low as I would have expected this to be discovered by now.

Adding the LoadMetadata interface is just a convenience, but it was required due to the other processing I needed to do in my Pig script.

I can try to create a test case (bson file) for this, but it will take some time, as I cannot give away my data.
- Geoff
