### PR TITLE
[Bugfix] Connection Leaks

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/BSONFileInputFormat.java
+++ b/core/src/main/java/com/mongodb/hadoop/BSONFileInputFormat.java
@@ -44,9 +44,7 @@ public class BSONFileInputFormat extends FileInputFormat {
     public RecordReader createRecordReader(final InputSplit split, final TaskAttemptContext context)
         throws IOException, InterruptedException {
 
-        BSONFileRecordReader reader = new BSONFileRecordReader();
-        reader.initialize(split, context);
-        return reader;
+        return new BSONFileRecordReader();
     }
 
     public static PathFilter getInputPathFilter(final JobContext context) {

--- a/core/src/main/java/com/mongodb/hadoop/splitter/BSONSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/BSONSplitter.java
@@ -111,6 +111,8 @@ public class BSONSplitter extends Configured implements Tool {
             BSONObject splitInfo = (BSONObject) callback.get();
             splits.add(createFileSplitFromBSON(splitInfo, fs, inputFile));
         }
+        fsDataStream.close();
+        fs.close();
         splitsList = splits;
     }//}}}
 


### PR DESCRIPTION
I am using BSON as the input format of our s3 input storage. In contrast with the HDFS, Amazon s3 seems to be sensitive to leaks. As reading massive files, I met tons of "org.apache.http.conn.ConnectionPoolTimeoutException." After some inspection, I found some leaks and patched it.

The first bug was in the BSONFileInputFormat. please see this code: [TextInputFormat](https://github.com/apache/hadoop-common/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/TextInputFormat.java) We must not initialize the BSONFileRecordReader. It seems to causes "double initialization." After removing this initializing routine, I eliminated the ConnectionPoolTimeoutException.

The second bug was in the BSONSplitter. Since the original routine did not close the fsDataStream and fs, It causes error for massive files, too.