### PR TITLE
Remove static modifier from BSON encoder/decoder to allow running multithreaded

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
+++ b/core/src/main/java/com/mongodb/hadoop/input/MongoInputSplit.java
@@ -55,8 +55,8 @@ public class MongoInputSplit extends InputSplit implements Writable, org.apache.
     protected boolean notimeout = false;
     protected transient DBCursor cursor;
 
-    protected static transient BSONEncoder _bsonEncoder = new BasicBSONEncoder();
-    protected static transient BSONDecoder _bsonDecoder = new BasicBSONDecoder();
+    protected transient BSONEncoder _bsonEncoder = new BasicBSONEncoder();
+    protected transient BSONDecoder _bsonDecoder = new BasicBSONDecoder();
     //CHECKSTYLE:ON
 
     public MongoInputSplit() {


### PR DESCRIPTION
Hi, currently if you use the mongodb hadoop core integration with Spark, you end up with a nasty InvalidStateException from the BSON decoder. See reports:

http://stackoverflow.com/questions/25254934/illegal-state-exception-mongo-hadoop-and-spark
http://stackoverflow.com/questions/25226515/exception-while-connecting-to-mongodb-in-spark
https://jira.mongodb.org/browse/HADOOP-154

This is because your BSON encoder/decoders are static in the MongoInputSplit.java. When Spark runs multithreaded, these get shared between all class instances in the same process, hence it has "issues" as all the threads are attempting to use the same decoder encoder at once.

Removing the static field modifier fixes it.
