### PR TITLE
Allowing tuples such as ("a", "b") to be imported as ["a", "b"]

### DIFF
--- a/pig/src/main/java/com/mongodb/hadoop/pig/BSONStorage.java
+++ b/pig/src/main/java/com/mongodb/hadoop/pig/BSONStorage.java
@@ -151,7 +151,7 @@ public class BSONStorage extends StoreFunc implements StoreMetadata {
                 // For example, {("a"),("b")} becomes ["a","b"] if
                 // unnamedStr == "t" and schema for bag is {<*>:(t:chararray)}
                 // <*> -> can be any string since the field name of the tuple in a bag should be ignored 
-                if (fs.length == 1 && fs[0].getName().equals(toIgnore)) {
+                if (fs.length == 1 && (fs[0].getName() == null || fs[0].getName().equals(toIgnore))) {
                     for (Tuple t : (DataBag) o) {
                         a.add(t.get(0));
                     }


### PR DESCRIPTION
Based on the code, 
writeField#186 will pass the `toIgnore` as null, which will then be used in getTypeForBSON#154.
If i need to get into that `if` block on #154, (with respect to the comments between 149-153) i just cannot, since fs[0].getName will have to be null for it to equal `toIgnore`. and if its null, it will just throw an NPE.

All i want to do is create an array ["a", "b"] and that doesn't seem possible with the current code
