### PR TITLE
Descending split key

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
@@ -141,6 +141,13 @@ public final class MongoConfigUtil {
     public static final String INPUT_SPLIT_KEY_PATTERN = "mongo.input.split.split_key_pattern";
 
     /**
+     * If the key specified for {@link #INPUT_SPLIT_KEY_PATTERN} is a descending index or
+     * is a compound key that contains a descending value then this should be set to {@code true}.<p/>
+     * Defaults to {@code false}.
+     **/
+    public static final String SPLIT_KEY_DESCENDING = "mongo.input.split.split_key_descending";
+
+    /**
      * If {@code true}, the driver will attempt to split the MongoDB Input data (if reading from Mongo) into multiple InputSplits to allow
      * parallelism/concurrency in processing within Hadoop.  That is to say, Hadoop will assign one InputSplit per mapper.
      * <p/>
@@ -174,6 +181,24 @@ public final class MongoConfigUtil {
      * Defaults to {@code false}
      */
     public static final String SPLITS_USE_RANGEQUERY = "mongo.input.split.use_range_queries";
+
+    /**
+     * The lower bound shard key to use when creating the input splits.<p/>
+     * Defaults to {@code null}.  Values must be provided for both this key
+     * and {@link #SPLITS_MAX_KEY} in order for the range to be used.  Remember
+     * that if your index is ordered descending then the value for this key
+     * will actually be greater than the value specified at {@link #SPLITS_MAX_KEY}.
+     **/
+    public static final String SPLITS_MIN_KEY = "mongo.input.split.split_key_min";
+
+    /**
+     * The upper bound shard key to use when creating the input splits.<p/>
+     * Defaults to {@code null}.  Values must be provided for both this key
+     * and {@link #SPLITS_MIN_KEY} in order for the range to be used.  Remember
+     * that if your index is ordered descending then the value for this key
+     * will actually be less than the value specified at {@link #SPLITS_MIN_KEY}.
+     **/
+    public static final String SPLITS_MAX_KEY = "mongo.input.split.split_key_max";
 
     /**
      * Shared MongoClient instance cache.
@@ -597,6 +622,14 @@ public final class MongoConfigUtil {
 
     public static void setRangeQueryEnabled(final Configuration conf, final boolean value) {
         conf.setBoolean(SPLITS_USE_RANGEQUERY, value);
+    }
+
+    public static boolean isSplitKeyDescending(final Configuration conf) {
+      return conf.getBoolean(SPLIT_KEY_DESCENDING, false);
+    }
+
+    public static void setSplitKeyDescending(final Configuration conf, final boolean value) {
+      conf.setBoolean(SPLIT_KEY_DESCENDING, value);
     }
 
     /**

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
@@ -142,7 +142,10 @@ public final class MongoConfigUtil {
 
     /**
      * If the key specified for {@link #INPUT_SPLIT_KEY_PATTERN} is a descending index or
-     * is a compound key that contains a descending value then this should be set to {@code true}.<p/>
+     * is a compound key that contains a descending value then this should be set to {@code true}.
+     * If {@link #SPLITS_MIN_KEY} and {@link #SPLITS_MAX_KEY} are specified and the max key value
+     * is less than the min key value then this should be set to {@code true}.  In all other
+     * cases this should either not be set or be set to {@code false}.<p/>
      * Defaults to {@code false}.
      **/
     public static final String SPLIT_KEY_DESCENDING = "mongo.input.split.split_key_descending";

--- a/core/src/test/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitterTest.java
+++ b/core/src/test/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitterTest.java
@@ -1,6 +1,7 @@
 package com.mongodb.hadoop.splitter;
 
 import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBList;
 import com.mongodb.DBCollection;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
@@ -16,6 +17,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 public class StandaloneMongoSplitterTest {
 
@@ -78,5 +80,87 @@ public class StandaloneMongoSplitterTest {
         MongoInputSplit split = splitter.createSplitFromBounds(lowerBound, upperBound);
         assertEquals(0, split.getMin().get("a"));
         assertEquals(10, split.getMax().get("a"));
+    }
+
+    @Test
+    public void testCreateSplitsNoRange() throws Exception {
+        Configuration config = new Configuration();
+        StandaloneMongoSplitter splitter = new StandaloneMongoSplitter(config);
+
+        BasicDBList list = new BasicDBList();
+        list.add(new BasicDBObject( "frame", "1500")); 
+        list.add(new BasicDBObject( "frame", "1000")); 
+        list.add(new BasicDBObject( "frame", "500")); 
+
+        List<InputSplit> splits = splitter.createSplits(list, null, null, false);
+        assertEquals(4, splits.size());
+
+        MongoInputSplit s1 = (MongoInputSplit)splits.get(0);
+        assertNull(s1.getMin().get("frame"));
+        assertEquals("1500", s1.getMax().get("frame"));
+
+        MongoInputSplit s2 = (MongoInputSplit)splits.get(1);
+        assertEquals("1500", s2.getMin().get("frame"));
+        assertEquals("1000", s2.getMax().get("frame"));
+
+        MongoInputSplit s4 = (MongoInputSplit)splits.get(3);
+        assertEquals("500", s4.getMin().get("frame"));
+        assertNull(s4.getMax().get("frame"));
+    }
+
+    @Test
+    public void testCreateSplitsRange() throws Exception {
+        Configuration config = new Configuration();
+        StandaloneMongoSplitter splitter = new StandaloneMongoSplitter(config);
+
+        BasicDBList list = new BasicDBList();
+        list.add(new BasicDBObject( "frame", "2000")); 
+        list.add(new BasicDBObject( "frame", "1500")); 
+        list.add(new BasicDBObject( "frame", "1000")); 
+
+        BasicDBObject splitMin = new BasicDBObject("frame", "500");
+        BasicDBObject splitMax = new BasicDBObject("frame", "2500");
+        List<InputSplit> splits = splitter.createSplits(list, splitMin, splitMax, false);
+        assertEquals(4, splits.size());
+
+        MongoInputSplit s1 = (MongoInputSplit)splits.get(0);
+        assertEquals("2500", s1.getMin().get("frame"));
+        assertEquals("2000", s1.getMax().get("frame"));
+
+        MongoInputSplit s2 = (MongoInputSplit)splits.get(1);
+        assertEquals("2000", s2.getMin().get("frame"));
+        assertEquals("1500", s2.getMax().get("frame"));
+
+        MongoInputSplit s3 = (MongoInputSplit)splits.get(3);
+        assertEquals("1000", s3.getMin().get("frame"));
+        assertEquals("500", s3.getMax().get("frame"));
+    }
+
+    @Test
+    public void testCreateSplitsRangeDescending() throws Exception {
+        Configuration config = new Configuration();
+        StandaloneMongoSplitter splitter = new StandaloneMongoSplitter(config);
+
+        BasicDBList list = new BasicDBList();
+        list.add(new BasicDBObject( "frame", "2000")); 
+        list.add(new BasicDBObject( "frame", "1500")); 
+        list.add(new BasicDBObject( "frame", "1000")); 
+
+        BasicDBObject splitMin = new BasicDBObject("frame", "2500");
+        BasicDBObject splitMax = new BasicDBObject("frame", "500");
+        List<InputSplit> splits = splitter.createSplits(list, splitMin, splitMax, true);
+        assertEquals(4, splits.size());
+
+        MongoInputSplit s1 = (MongoInputSplit)splits.get(0);
+        assertEquals("2500", s1.getMin().get("frame"));
+        assertEquals("2000", s1.getMax().get("frame"));
+
+        MongoInputSplit s2 = (MongoInputSplit)splits.get(1);
+        assertEquals("2000", s2.getMin().get("frame"));
+        assertEquals("1500", s2.getMax().get("frame"));
+
+        MongoInputSplit s3 = (MongoInputSplit)splits.get(3);
+        assertEquals("1000", s3.getMin().get("frame"));
+        assertEquals("500", s3.getMax().get("frame"));
     }
 }


### PR DESCRIPTION
Support specifying "min" and "max" values for the "splitVector" command.  Support descending split keys.  If a split key is using an index with a descending values, then the key specified for "min" will be greater than the key specified for "max".  We need to swap the min and max values when creating the InputSplits.