### PR TITLE
Fix build on Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,9 @@ configure(subprojects) {
         options.links 'http://docs.oracle.com/javase/6/docs/api/'
         options.links 'http://hadoop.apache.org/docs/r2.4.0/api'
         options.links 'http://api.mongodb.org/java/2.12.3/'
+        if (JavaVersion.current().isJava8Compatible()) {
+          options.addStringOption('Xdoclint:none', '-quiet')
+        }
     }
 
     gradle.taskGraph.whenReady { taskGraph ->


### PR DESCRIPTION
When I tried to build mongo-hadoop on java 8 I had errors likes:

```
MongoConfigUtil.java:173: error: self-closing element not allowed
     * <p/>
       ^
```

It seems that for JDK 8 it has been decided that tags like <br /> and <p /> should generate errors, because they are invalid (strict) HTML 4.

Good discussion about this on JDK mail list: http://mail.openjdk.java.net/pipermail/core-libs-dev/2013-July/019261.html