### PR TITLE
Put printing of every record as debug output, not info output. Printing ...

### DIFF
--- a/pig/src/main/java/com/mongodb/hadoop/pig/MongoStorage.java
+++ b/pig/src/main/java/com/mongodb/hadoop/pig/MongoStorage.java
@@ -99,7 +99,7 @@ public class MongoStorage extends StoreFunc implements StoreMetadata {
 
 
     public void putNext(final Tuple tuple) throws IOException {
-        LOG.info("writing " + tuple.toString());
+        LOG.debug("writing " + tuple.toString());
         final BasicDBObjectBuilder builder = BasicDBObjectBuilder.start();
 
         ResourceFieldSchema[] fields = this.schema.getFields();
@@ -107,7 +107,7 @@ public class MongoStorage extends StoreFunc implements StoreMetadata {
             writeField(builder, fields[i], tuple.get(i));
         }
 
-        LOG.info("writing out:" + builder.get().toString());
+        LOG.debug("writing out:" + builder.get().toString());
         //noinspection unchecked
         recordWriter.write(null, builder.get());
     }


### PR DESCRIPTION
...every record we store is literally insane and slows things down incredibly.