### PR TITLE
Issues with MapReduce job taking data from sharded MongoDB collection

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/splitter/MongoCollectionSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/MongoCollectionSplitter.java
@@ -90,9 +90,6 @@ public abstract class MongoCollectionSplitter extends MongoSplitter {
             if (cur != null) {
                 cur.close();
             }
-            if (configDB != null) {
-                MongoConfigUtil.close(configDB.getMongo());
-            }
         }
         return shardsMap;
     }


### PR DESCRIPTION
1- Stop sharing MongoDB client object for all threads : this causes issues when having multi-threaded job taking data from a sharded MongoDB collection.

Here is the exception that can be thrown when a MongoDB connection is closed in such a case:
15/03/03 20:32:39 WARN NewHadoopRDD: Exception in RecordReader.close()
java.lang.IllegalStateException: open
	at org.bson.util.Assertions.isTrue(Assertions.java:36)
	at com.mongodb.DBTCPConnector.say(DBTCPConnector.java:162)
	at com.mongodb.DBApiLayer.killCursors(DBApiLayer.java:242)
	at com.mongodb.QueryResultIterator.killCursor(QueryResultIterator.java:262)
	at com.mongodb.QueryResultIterator.close(QueryResultIterator.java:179)
	at com.mongodb.DBCursor.close(DBCursor.java:390)
	at com.mongodb.hadoop.input.MongoRecordReader.close(MongoRecordReader.java:45)


2- getShardsMap is currently closing the MongoDB connection, which is reused further when looping on all chunks (while (cur.hasNext()) at ShardChunkMongoSplitter.java#93).

This causes the next MongoDB query to fail because connection has been closed.