### PR TITLE
splitting error when multi hosts in mongoURI

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
@@ -327,7 +327,7 @@ public final class MongoConfigUtil {
         if (raw != null && !raw.trim().isEmpty()) {
             for (String connectionString : raw.split("mongodb://")) {
                 // Try to be forgiving with formatting.
-                connectionString = StringUtils.strip(connectionString, ", ");
+                connectionString = StringUtils.splitByWholeSeparator(connectionString, ", ");
                 if (!connectionString.isEmpty()) {
                     result.add(
                       new MongoClientURI("mongodb://" + connectionString));


### PR DESCRIPTION
when user specified a mongoURI which contains multiple hosts the following method call will fail.
for example: "mongodb://aaa,bbb,ccc/blog_extra.hottag",
and this method produces ["mongodb://aaa", "bbb", "ccc/blog_extra.hottag"] as an result.