### PR TITLE
Support for min/max parameters for splitter

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitter.java
@@ -168,13 +168,11 @@ public class StandaloneMongoSplitter extends MongoCollectionSplitter {
                 LOG.warn("WARNING: No Input Splits were calculated by the split code. Proceeding with a *single* split. Data may be too"
                          + " small, try lowering 'mongo.input.split_size' if this is undesirable.");
             }
-            
+
             BasicDBObject lastKey = null; // Lower boundary of the first min split
-            //splitKey is BSONObject of shape { key: 1 }
-            
-            String splitKeyString = (new BasicDBObject(splitKey.toMap())).keySet().iterator().next();
+
             //If splitKeyMin has been used, use it as first boundary.
-            if(splitKeyMin.containsField(splitKeyString)) {
+            if(!splitKeyMin.toMap().isEmpty()) {
                 lastKey = new BasicDBObject(splitKeyMin.toMap());
             }
             for (final Object aSplitData : splitData) {
@@ -184,8 +182,8 @@ public class StandaloneMongoSplitter extends MongoCollectionSplitter {
             }
 
             BasicDBObject maxKey = null;
-          //If splitKeyMax has been used, use it as last boundary.
-            if(splitKeyMax.containsField(splitKeyString)) {
+            //If splitKeyMax has been used, use it as last boundary.
+            if(!splitKeyMax.toMap().isEmpty()) {
                 maxKey = new BasicDBObject(splitKeyMax.toMap());
             }
             // Last max split

--- a/core/src/main/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitter.java
@@ -65,6 +65,8 @@ public class StandaloneMongoSplitter extends MongoCollectionSplitter {
     @Override
     public List<InputSplit> calculateSplits() throws SplitFailedException {
         final DBObject splitKey = MongoConfigUtil.getInputSplitKey(getConfiguration());
+        final DBObject splitKeyMax = MongoConfigUtil.getMaxSplitKey(getConfiguration());
+        final DBObject splitKeyMin = MongoConfigUtil.getMinSplitKey(getConfiguration());
         final int splitSize = MongoConfigUtil.getSplitSize(getConfiguration());
         final MongoClientURI inputURI;
         DBCollection inputCollection = null;
@@ -85,6 +87,8 @@ public class StandaloneMongoSplitter extends MongoCollectionSplitter {
             LOG.info("Running splitvector to check splits against " + inputURI);
             final DBObject cmd = BasicDBObjectBuilder.start("splitVector", ns)
                                      .add("keyPattern", splitKey)
+                                     .add("min", splitKeyMin)
+                                     .add("max", splitKeyMax)
                                           // force:True is misbehaving it seems
                                      .add("force", false)
                                      .add("maxChunkSize", splitSize)
@@ -164,17 +168,28 @@ public class StandaloneMongoSplitter extends MongoCollectionSplitter {
                 LOG.warn("WARNING: No Input Splits were calculated by the split code. Proceeding with a *single* split. Data may be too"
                          + " small, try lowering 'mongo.input.split_size' if this is undesirable.");
             }
-
+            
             BasicDBObject lastKey = null; // Lower boundary of the first min split
-
+            //splitKey is BSONObject of shape { key: 1 }
+            
+            String splitKeyString = (new BasicDBObject(splitKey.toMap())).keySet().iterator().next();
+            //If splitKeyMin has been used, use it as first boundary.
+            if(splitKeyMin.containsField(splitKeyString)) {
+                lastKey = new BasicDBObject("value", splitKeyMin.get(splitKeyString));
+            }
             for (final Object aSplitData : splitData) {
                 final BasicDBObject currentKey = (BasicDBObject) aSplitData;
                 returnVal.add(createSplitFromBounds(lastKey, currentKey));
                 lastKey = currentKey;
             }
 
-            // Last max split, with empty upper boundary
-            final MongoInputSplit lastSplit = createSplitFromBounds(lastKey, null);
+            BasicDBObject maxKey = null;
+          //If splitKeyMax has been used, use it as last boundary.
+            if(splitKeyMax.containsField(splitKeyString)) {
+                maxKey = new BasicDBObject("value", splitKeyMax.get(splitKeyString));
+            }
+            // Last max split
+            final MongoInputSplit lastSplit = createSplitFromBounds(lastKey, maxKey);
             returnVal.add(lastSplit);
         } finally {
             if (inputCollection != null) {

--- a/core/src/main/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitter.java
@@ -175,7 +175,7 @@ public class StandaloneMongoSplitter extends MongoCollectionSplitter {
             String splitKeyString = (new BasicDBObject(splitKey.toMap())).keySet().iterator().next();
             //If splitKeyMin has been used, use it as first boundary.
             if(splitKeyMin.containsField(splitKeyString)) {
-                lastKey = new BasicDBObject("value", splitKeyMin.get(splitKeyString));
+                lastKey = new BasicDBObject(splitKeyMin.toMap());
             }
             for (final Object aSplitData : splitData) {
                 final BasicDBObject currentKey = (BasicDBObject) aSplitData;
@@ -186,7 +186,7 @@ public class StandaloneMongoSplitter extends MongoCollectionSplitter {
             BasicDBObject maxKey = null;
           //If splitKeyMax has been used, use it as last boundary.
             if(splitKeyMax.containsField(splitKeyString)) {
-                maxKey = new BasicDBObject("value", splitKeyMax.get(splitKeyString));
+                maxKey = new BasicDBObject(splitKeyMax.toMap());
             }
             // Last max split
             final MongoInputSplit lastSplit = createSplitFromBounds(lastKey, maxKey);

--- a/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
+++ b/core/src/main/java/com/mongodb/hadoop/util/MongoConfigUtil.java
@@ -17,15 +17,15 @@
 
 package com.mongodb.hadoop.util;
 
-import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+import com.mongodb.MongoURI;
+import com.mongodb.hadoop.splitter.MongoSplitter;
+import com.mongodb.util.JSON;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -38,15 +38,14 @@ import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.Partitioner;
 import org.apache.hadoop.mapreduce.Reducer;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
-import com.mongodb.Mongo;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
-import com.mongodb.MongoURI;
-import com.mongodb.hadoop.splitter.MongoSplitter;
-import com.mongodb.util.JSON;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Configuration helper tool for MongoDB related Map/Reduce jobs

--- a/core/src/test/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitterTest.java
+++ b/core/src/test/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitterTest.java
@@ -1,18 +1,5 @@
 package com.mongodb.hadoop.splitter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.net.UnknownHostException;
-import java.util.List;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.InputSplit;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBCollection;
@@ -22,25 +9,35 @@ import com.mongodb.MongoClientURI;
 import com.mongodb.hadoop.input.MongoInputSplit;
 import com.mongodb.hadoop.util.MongoClientURIBuilder;
 import com.mongodb.hadoop.util.MongoConfigUtil;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.UnknownHostException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class StandaloneMongoSplitterTest {
 
     private static MongoClientURI uri;
 
-    
     @BeforeClass
     public static void setUp() {
         MongoClient client = new MongoClient("localhost", 27017);
         uri = new MongoClientURIBuilder()
-            .collection("mongo_hadoop", "splitter_test")
-            .build();
+                                 .collection("mongo_hadoop", "splitter_test")
+                                 .build();
         DBCollection collection = client.getDB(uri.getDatabase()).getCollection(uri.getCollection());
         collection.drop();
         collection.createIndex("value");
         for (int i = 0; i < 40000; i++) {
             collection.insert(new BasicDBObject("_id", i)
-                .append("value", i)
-                );
+                                  .append("value", i)
+                             );
         }
     }
 
@@ -53,8 +50,7 @@ public class StandaloneMongoSplitterTest {
         assertFalse("Should find at least one split", inputSplits.isEmpty());
 
     }
-    
-    
+
     @Test
     public void unshardedCollectionMinMax() throws UnknownHostException, SplitFailedException {
         Configuration config = new Configuration();
@@ -63,16 +59,11 @@ public class StandaloneMongoSplitterTest {
         DBObject inputSplitKey = BasicDBObjectBuilder.start("value", 1).get();
         MongoConfigUtil.setInputSplitKey(config, inputSplitKey);
         MongoConfigUtil.setSplitSize(config, 1);
-        
         List<InputSplit> regularSplits = splitter.calculateSplits();
-        
         MongoConfigUtil.setMinSplitKey(config, "{value:100}");
         MongoConfigUtil.setMaxSplitKey(config, "{value:39900}");
-        
         List<InputSplit> inputSplits = splitter.calculateSplits();
-        
         assertTrue("regularSplits should be bigger than minmaxSplit", regularSplits.size() >= inputSplits.size());
-
     }
 
     @Test

--- a/core/src/test/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitterTest.java
+++ b/core/src/test/java/com/mongodb/hadoop/splitter/StandaloneMongoSplitterTest.java
@@ -1,42 +1,77 @@
 package com.mongodb.hadoop.splitter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.UnknownHostException;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.hadoop.input.MongoInputSplit;
 import com.mongodb.hadoop.util.MongoClientURIBuilder;
 import com.mongodb.hadoop.util.MongoConfigUtil;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.mapreduce.InputSplit;
-import org.junit.Test;
-
-import java.net.UnknownHostException;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class StandaloneMongoSplitterTest {
 
-    @Test
-    public void unshardedCollection() throws UnknownHostException, SplitFailedException {
+    private static MongoClientURI uri;
+
+    
+    @BeforeClass
+    public static void setUp() {
         MongoClient client = new MongoClient("localhost", 27017);
-        MongoClientURI uri = new MongoClientURIBuilder()
-                                 .collection("mongo_hadoop", "splitter_test")
-                                 .build();
+        uri = new MongoClientURIBuilder()
+            .collection("mongo_hadoop", "splitter_test")
+            .build();
         DBCollection collection = client.getDB(uri.getDatabase()).getCollection(uri.getCollection());
         collection.drop();
-        for (int i = 0; i < 10000; i++) {
+        collection.createIndex("value");
+        for (int i = 0; i < 40000; i++) {
             collection.insert(new BasicDBObject("_id", i)
-                                  .append("value", i)
-                             );
+                .append("value", i)
+                );
         }
+    }
+
+    @Test
+    public void unshardedCollection() throws UnknownHostException, SplitFailedException {
         Configuration config = new Configuration();
         StandaloneMongoSplitter splitter = new StandaloneMongoSplitter(config);
         MongoConfigUtil.setInputURI(config, uri);
         List<InputSplit> inputSplits = splitter.calculateSplits();
         assertFalse("Should find at least one split", inputSplits.isEmpty());
+
+    }
+    
+    
+    @Test
+    public void unshardedCollectionMinMax() throws UnknownHostException, SplitFailedException {
+        Configuration config = new Configuration();
+        StandaloneMongoSplitter splitter = new StandaloneMongoSplitter(config);
+        MongoConfigUtil.setInputURI(config, uri);
+        DBObject inputSplitKey = BasicDBObjectBuilder.start("value", 1).get();
+        MongoConfigUtil.setInputSplitKey(config, inputSplitKey);
+        MongoConfigUtil.setSplitSize(config, 1);
+        
+        List<InputSplit> regularSplits = splitter.calculateSplits();
+        
+        MongoConfigUtil.setMinSplitKey(config, "{value:100}");
+        MongoConfigUtil.setMaxSplitKey(config, "{value:39900}");
+        
+        List<InputSplit> inputSplits = splitter.calculateSplits();
+        
+        assertTrue("regularSplits should be bigger than minmaxSplit", regularSplits.size() >= inputSplits.size());
 
     }
 


### PR DESCRIPTION
Support for INPUT_SPLIT_KEY_MIN(mongo.input.split.split_key_min) and INPUT_SPLIT_KEY_MAX(mongo.input.split.split_key_max) in order to narrow amounts of records to process before splits are done.. 
Only supported in StandaloneMongoSplitter (for now).
This code has been tested again local production with success.

Refer to https://github.com/mongodb/mongo/blob/master/src/mongo/s/d_split.cpp#L216 for further details.