### PR TITLE
TODO: unorderedBulkOperation support?

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/output/MongoOutputCommitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/output/MongoOutputCommitter.java
@@ -134,6 +134,7 @@ public class MongoOutputCommitter extends OutputCommitter {
             taskContext.getConfiguration());
         int curBatchSize = 0;
         DBCollection coll = getDbCollectionByRoundRobin();
+        // TODO: unorderedBulkOperation support?
         BulkWriteOperation bulkOp = coll.initializeOrderedBulkOperation();
 
         // Read Writables out of the temporary file.
@@ -245,4 +246,3 @@ public class MongoOutputCommitter extends OutputCommitter {
     }
 
 }
-


### PR DESCRIPTION
didn't see the issues tab here, figured this'd approximate it. is there something about the larger mongo-hadoop ecosystem that makes it impossible to support unordered bulk writes/updates/upserts or could that be added?