### PR TITLE
Use query projection in MongoPaginatingSplitter

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/splitter/MongoPaginatingSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/MongoPaginatingSplitter.java
@@ -56,6 +56,12 @@ public class MongoPaginatingSplitter extends MongoCollectionSplitter {
                 + "compound key.");
         }
         String splitKey = splitKeys.iterator().next();
+
+        DBObject splitKeyProjection = new BasicDBObject(splitKey, 1);
+        if (!splitKey.equals("_id")) {
+            splitKeyProjection.put("_id", 0);
+        }
+
         int minDocs = MongoConfigUtil.getInputSplitMinDocs(conf);
         DBCollection inputCollection =
           MongoConfigUtil.getInputCollection(conf);
@@ -68,7 +74,7 @@ public class MongoPaginatingSplitter extends MongoCollectionSplitter {
         try {
             do {
                 if (null == minBound) {
-                    cursor = inputCollection.find(query);
+                    cursor = inputCollection.find(query, splitKeyProjection);
                 } else {
                     if (null == rangeObj) {
                         rangeObj =
@@ -79,7 +85,7 @@ public class MongoPaginatingSplitter extends MongoCollectionSplitter {
                         ((DBObject) rangeObj.get(splitKey))
                           .put("$gte", minBound);
                     }
-                    cursor = inputCollection.find(rangeObj);
+                    cursor = inputCollection.find(rangeObj, splitKeyProjection);
                 }
                 cursor = cursor.sort(splitKeyObj).skip(minDocs).limit(1);
 


### PR DESCRIPTION
Since `MongoPaginatingSplitter` actually uses only one field (split key) from its intermediate queries' results, make this intention explicit by using query projection. If there is an index on the split key field (which is not unlikely, since the default split key is `"_id"`) and the queries use that index, this will make that index [cover](https://docs.mongodb.com/manual/core/query-optimization/#covered-query) the queries, which would be a noticeable performance improvement.