### PR TITLE
support hive 3 serde interfaces/remove deprecated hive api references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ apply plugin: 'com.github.ben-manes.versions'
 ext.configDir = new File(rootDir, 'config')
 ext.hadoopBinaries = "${rootDir}/hadoop-binaries".toString()
 ext.javaDriverVersion = '3.2.1'
-ext.hiveVersion = System.getenv("HIVE_VERSION") ?: '1.2.1'
+ext.hiveVersion = System.getenv("HIVE_VERSION") ?: '3.1.1'
 ext.pigVersion = System.getenv("PIG_VERSION") ?: '0.15.0'
-ext.hadoopVersion = System.getenv("HADOOP_VERSION") ?: '2.7.2'
+ext.hadoopVersion = System.getenv("HADOOP_VERSION") ?: '3.1.0'
 ext.sparkVersion = System.getenv("SPARK_VERSION") ?: '1.6.0'
 ext.scalaVersion = System.getenv("SCALA_VERSION") ?: '2.11'
 ext.isHadoopV1 = "$hadoopVersion".startsWith("1.")

--- a/hive/src/main/java/com/mongodb/hadoop/hive/BSONSerDe.java
+++ b/hive/src/main/java/com/mongodb/hadoop/hive/BSONSerDe.java
@@ -22,7 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde.serdeConstants;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
@@ -62,7 +62,7 @@ import static java.lang.String.format;
  * The BSONSerDe class deserializes (parses) and serializes object from BSON to Hive represented object. It's initialized with the hive
  * columns and hive recognized types as well as other config variables mandated by the StorageHanders.
  */
-public class BSONSerDe implements SerDe {
+public class BSONSerDe extends AbstractSerDe {
     private static final Log LOG = LogFactory.getLog(BSONSerDe.class);
 
     // stores the 1-to-1 mapping of MongoDB fields to hive columns

--- a/hive/src/main/java/com/mongodb/hadoop/hive/MongoStorageHandler.java
+++ b/hive/src/main/java/com/mongodb/hadoop/hive/MongoStorageHandler.java
@@ -25,7 +25,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
-import org.apache.hadoop.hive.metastore.MetaStoreUtils;
+import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.index.IndexPredicateAnalyzer;
@@ -36,8 +36,8 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.Deserializer;
-import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
@@ -84,7 +84,7 @@ public class MongoStorageHandler extends DefaultStorageHandler
     }
 
     @Override
-    public Class<? extends SerDe> getSerDeClass() {
+    public Class<? extends AbstractSerDe> getSerDeClass() {
         return BSONSerDe.class;
     }
 

--- a/hive/src/main/java/com/mongodb/hadoop/hive/input/HiveMongoInputFormat.java
+++ b/hive/src/main/java/com/mongodb/hadoop/hive/input/HiveMongoInputFormat.java
@@ -32,7 +32,7 @@ import com.mongodb.util.JSON;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.index.IndexPredicateAnalyzer;
 import org.apache.hadoop.hive.ql.index.IndexSearchCondition;
 import org.apache.hadoop.hive.ql.io.HiveInputFormat;
@@ -131,7 +131,7 @@ public class HiveMongoInputFormat extends HiveInputFormat<BSONWritable, BSONWrit
         String serializedExpr = conf.get(TableScanDesc.FILTER_EXPR_CONF_STR);
         if (serializedExpr != null) {
             ExprNodeGenericFuncDesc expr =
-              Utilities.deserializeExpression(serializedExpr);
+                SerializationUtilities.deserializeExpression(serializedExpr);
             IndexPredicateAnalyzer analyzer =
               IndexPredicateAnalyzer.createAnalyzer(false);
 


### PR DESCRIPTION
Trying with Hive 3.1.1 and Hadoop 3.1.0 and started failing with following exceptions.
Hope above patch help fix the following issues if you come across same.

java.lang.NoClassDefFoundError: org/apache/hadoop/hive/serde2/SerDe
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:368)

And while deleting a table 
java.lang.NoClassDefFoundError: org/apache/hadoop/hive/metastore/MetaStoreUtils
